### PR TITLE
초대가입 기능 수정 완료

### DIFF
--- a/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
+++ b/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
@@ -32,6 +32,7 @@ public enum ErrorCode {
 	INVITE_NAME_NOT_VALID(BAD_REQUEST, "C_019", "초대회원 이름이 유효하지 않습니다."),
 	EXERCISE_NOT_FOUND(NOT_FOUND, "C_020", "해당 운동이 존재하지 않습니다."),
 	PASSWORD_NOT_VALID(BAD_REQUEST, "C_019", "비밀번호가 일치하지 않습니다."),
+	DATETIME_NOT_VALID(BAD_REQUEST, "C_019", "시작날짜와 종료날짜가 유효하지 않습니다."),
 
 	MEMBER_NAME_LENGTH_NOT_VALID(BAD_REQUEST, "C_020", "이름의 길이는 2자 이상이여야 합니다."),
 	MEMBER_NAME_NOT_VALID(BAD_REQUEST, "C_021", "이름은 한글 또는 영어만 입력할 수 있습니다."),

--- a/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
+++ b/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
@@ -29,7 +29,7 @@ public enum ErrorCode {
 	STAND_BY_SCHEDULE_NOT_FOUND(NOT_FOUND, "C_016", "대기한 일정을 찾을 수 없습니다."),
 	NOT_MATCH_PASSWORD(BAD_REQUEST, "C_017", "확인 비밀번호가 일치하지 않습니다."),
 	INVITE_LINK_NOT_FOUND(NOT_FOUND, "C_018", "초대링크를 찾을 수 없습니다."),
-	INVITE_LINK_NOT_VALID(BAD_REQUEST, "C_019", "초대링크가 유효하지 않습니다."),
+	INVITE_NAME_NOT_VALID(BAD_REQUEST, "C_019", "초대회원 이름이 유효하지 않습니다."),
 	EXERCISE_NOT_FOUND(NOT_FOUND, "C_020", "해당 운동이 존재하지 않습니다."),
 	PASSWORD_NOT_VALID(BAD_REQUEST, "C_019", "비밀번호가 일치하지 않습니다."),
 

--- a/src/main/java/com/tobe/healthy/config/error/OAuthError.java
+++ b/src/main/java/com/tobe/healthy/config/error/OAuthError.java
@@ -23,4 +23,15 @@ public class OAuthError {
 		private String resultcode;
 		private String message;
 	}
+
+	@Data
+	public static class GoogleError {
+		@JsonProperty("error")
+		private String error;
+
+		@JsonProperty("error_description")
+		private String errorDescription;
+
+	}
+
 }

--- a/src/main/java/com/tobe/healthy/gym/application/GymMembershipService.java
+++ b/src/main/java/com/tobe/healthy/gym/application/GymMembershipService.java
@@ -1,0 +1,42 @@
+package com.tobe.healthy.gym.application;
+
+import com.tobe.healthy.config.error.CustomException;
+import com.tobe.healthy.gym.domain.dto.in.MembershipAddCommand;
+import com.tobe.healthy.gym.domain.entity.Gym;
+import com.tobe.healthy.gym.domain.entity.GymMembership;
+import com.tobe.healthy.gym.repository.GymMembershipRepository;
+import com.tobe.healthy.gym.repository.GymRepository;
+import com.tobe.healthy.member.domain.entity.Member;
+import com.tobe.healthy.member.repository.MemberRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import static com.tobe.healthy.config.error.ErrorCode.*;
+
+@Service
+@Transactional
+@RequiredArgsConstructor
+@Slf4j
+public class GymMembershipService {
+
+    private final GymMembershipRepository gymMembershipRepository;
+    private final MemberRepository memberRepository;
+    private final GymRepository gymRepository;
+
+    public void registerGymMembership(MembershipAddCommand command) {
+        Member member = memberRepository.findById(command.getMemberId())
+                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
+        Gym gym = gymRepository.findById(command.getGymId())
+                .orElseThrow(() -> new CustomException(GYM_NOT_FOUND));
+
+        if(command.getGymStartDt().isAfter(command.getGymEndDt())){
+            throw new CustomException(DATETIME_NOT_VALID);
+        }
+        member.registerGym(gym);
+        GymMembership gymMembership = new GymMembership(gym, member, command.getLessonCnt(), command.getGymStartDt(), command.getGymEndDt());
+        gymMembershipRepository.save(gymMembership);
+    }
+
+}

--- a/src/main/java/com/tobe/healthy/gym/domain/dto/in/MembershipAddCommand.java
+++ b/src/main/java/com/tobe/healthy/gym/domain/dto/in/MembershipAddCommand.java
@@ -1,0 +1,44 @@
+package com.tobe.healthy.gym.domain.dto.in;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.PositiveOrZero;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+
+@Data
+public class MembershipAddCommand {
+
+    @Schema(description = "헬스장 번호", example = "1")
+    @NotEmpty(message = "헬스장 번호를 입력해주세요.")
+    private Long gymId;
+
+    @Schema(description = "학생 번호", example = "1")
+    @NotEmpty(message = "학생 번호를 입력해주세요.")
+    private Long memberId;
+
+    @Schema(description = "PT 횟수", example = "10")
+    @PositiveOrZero(message = "0 또는 양수를 입력해주세요.")
+    private int lessonCnt;
+
+    @Schema(description = "헬스장 이용권 시작날짜", example = "2024-02-01")
+    private LocalDate gymStartDt;
+
+    @Schema(description = "헬스장 이용권 종료날짜", example = "2024-05-01")
+    private LocalDate gymEndDt;
+
+    @Builder
+    public MembershipAddCommand(Long gymId, Long memberId, int lessonCnt, LocalDate gymStartDt, LocalDate gymEndDt){
+        this.gymId = gymId;
+        this.memberId = memberId;
+        this.lessonCnt = lessonCnt;
+        this.gymStartDt = gymStartDt;
+        this.gymEndDt = gymEndDt;
+    }
+
+}
+
+
+

--- a/src/main/java/com/tobe/healthy/gym/domain/entity/GymMembership.java
+++ b/src/main/java/com/tobe/healthy/gym/domain/entity/GymMembership.java
@@ -1,0 +1,53 @@
+package com.tobe.healthy.gym.domain.entity;
+
+import com.tobe.healthy.common.BaseTimeEntity;
+import com.tobe.healthy.gym.domain.dto.in.MembershipAddCommand;
+import com.tobe.healthy.member.domain.entity.Member;
+import jakarta.persistence.*;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicUpdate;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@Getter
+@DynamicUpdate
+public class GymMembership extends BaseTimeEntity<GymMembership, Long> {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "gym_membership_id")
+    private Long id;
+
+    @ManyToOne
+    @JoinColumn(name = "gym_id")
+    private Gym gym;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ColumnDefault("0")
+    private int lessonCnt = 0;
+
+    private LocalDate gymStartDt;
+    private LocalDate gymEndDt;
+
+    @Builder
+    public GymMembership(Gym gym, Member member, int lessonCnt, LocalDate gymStartDt, LocalDate gymEndDt) {
+        this.gym = gym;
+        this.member = member;
+        this.lessonCnt = lessonCnt;
+        this.gymStartDt = gymStartDt;
+        this.gymEndDt = gymEndDt;
+    }
+
+}

--- a/src/main/java/com/tobe/healthy/gym/presentation/GymMembershipController.java
+++ b/src/main/java/com/tobe/healthy/gym/presentation/GymMembershipController.java
@@ -1,0 +1,37 @@
+package com.tobe.healthy.gym.presentation;
+
+import com.tobe.healthy.common.ResponseHandler;
+import com.tobe.healthy.gym.application.GymMembershipService;
+import com.tobe.healthy.gym.domain.dto.in.MembershipAddCommand;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/membership/v1")
+@Slf4j
+@Valid
+@Tag(name = "04-01.헬스장 회원권 API", description = "헬스장 회원권 API")
+public class GymMembershipController {
+
+	private final GymMembershipService gymMembershipService;
+
+	@Operation(summary = "트레이너가 학생의 헬스장 이용권(시작날짜~종료날짜), PT 수업 횟수를 등록한다.",
+			description = "트레이너가 학생의 헬스장 이용권(시작날짜~종료날짜), PT 수업 횟수를 등록한다.",
+			responses = {
+					@ApiResponse(responseCode = "200", description = "헬스장 이용권, 수업권을 등록하였습니다.")
+			})
+	@PostMapping
+	public ResponseHandler<Void> registerGymMembership(@RequestBody MembershipAddCommand command) {
+		gymMembershipService.registerGymMembership(command);
+		return ResponseHandler.<Void>builder()
+				.message("헬스장 이용권, 수업권을 등록하였습니다.")
+				.build();
+	}
+
+}

--- a/src/main/java/com/tobe/healthy/gym/repository/GymMembershipRepository.java
+++ b/src/main/java/com/tobe/healthy/gym/repository/GymMembershipRepository.java
@@ -1,0 +1,7 @@
+package com.tobe.healthy.gym.repository;
+
+import com.tobe.healthy.gym.domain.entity.GymMembership;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface GymMembershipRepository extends JpaRepository<GymMembership, Long> {
+}

--- a/src/main/java/com/tobe/healthy/member/application/MemberService.java
+++ b/src/main/java/com/tobe/healthy/member/application/MemberService.java
@@ -8,6 +8,7 @@ import com.tobe.healthy.config.OAuthProperties;
 import com.tobe.healthy.config.error.CustomException;
 import com.tobe.healthy.config.error.OAuthError.KakaoError;
 import com.tobe.healthy.config.error.OAuthError.NaverError;
+import com.tobe.healthy.config.error.OAuthError.GoogleError;
 import com.tobe.healthy.config.error.OAuthException;
 import com.tobe.healthy.config.security.JwtTokenGenerator;
 import com.tobe.healthy.file.domain.entity.Profile;
@@ -465,10 +466,11 @@ public class MemberService {
 					.accept(MediaType.APPLICATION_JSON)
 					.bodyValue(requestBody)
 					.retrieve()
-//			.onStatus(HttpStatusCode::is4xxClientError,
-//				response -> Mono.error(RuntimeException::new))
-//			.onStatus(HttpStatusCode::is5xxServerError,
-//				response -> Mono.error(RuntimeException::new))
+					.onStatus(HttpStatusCode::isError, response ->
+							response.bodyToMono(GoogleError.class).flatMap(e -> {
+								log.error("error => {}", e);
+								return Mono.error(new OAuthException(e.getErrorDescription()));
+							}))
 					.bodyToMono(OAuthInfo.class);
 		}catch (Exception e){
 			e.printStackTrace();

--- a/src/main/java/com/tobe/healthy/member/domain/dto/MemberDto.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/MemberDto.java
@@ -19,6 +19,9 @@ public class MemberDto {
 	private String userId;
 	private String email;
 	private String name;
+	private int age;
+	private int height;
+	private int weight;
 	private boolean delYn;
 
 	private ProfileDto profile;
@@ -34,6 +37,9 @@ public class MemberDto {
 			.userId(member.getUserId())
 			.email(member.getEmail())
 			.name(member.getName())
+//			.age(member.getAge())
+//			.height(member.getHeight())
+//			.weight(member.getWeight())
 			.delYn(member.isDelYn())
 			.memberType(member.getMemberType())
 			.pushAlarmStatus(member.getPushAlarmStatus())

--- a/src/main/java/com/tobe/healthy/member/domain/dto/in/MemberJoinCommand.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/in/MemberJoinCommand.java
@@ -35,6 +35,6 @@ public class MemberJoinCommand {
     @NotNull(message = "회원 구분이 필요합니다.")
     private MemberType memberType;
 
-    @Schema(description = "초대링크로 가입하는 경우 트레이너 아이디", example = "초대링크로 가입하는 경우 트레이너 아이디")
-    private Long trainerId;
+    @Schema(description = "초대링크로 가입하는 경우 uuid")
+    private String uuid;
 }

--- a/src/main/java/com/tobe/healthy/member/domain/dto/out/InvitationMappingResult.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/out/InvitationMappingResult.java
@@ -13,14 +13,20 @@ import lombok.Data;
 public class InvitationMappingResult {
 
     private MemberDto trainer;
-    private GymDto gym;
-    private String email;
+    private String name;
+    private int lessonNum;
+    private int age;
+    private int height;
+    private int weight;
 
-    public static InvitationMappingResult create(Member member, String email){
+    public static InvitationMappingResult create(Member member, String name, int lessonNum, int age, int height, int weight){
         return InvitationMappingResult.builder()
                 .trainer(MemberDto.from(member))
-                .gym(GymDto.from(member.getGym()))
-                .email(email)
+                .name(name)
+                .lessonNum(lessonNum)
+                .age(age)
+                .height(height)
+                .weight(weight)
                 .build();
     }
 }

--- a/src/main/java/com/tobe/healthy/member/domain/dto/out/InvitationMappingResult.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/out/InvitationMappingResult.java
@@ -7,6 +7,9 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
 @Data
 @AllArgsConstructor
 @Builder
@@ -14,19 +17,17 @@ public class InvitationMappingResult {
 
     private MemberDto trainer;
     private String name;
-    private int lessonNum;
-    private int age;
-    private int height;
-    private int weight;
+    private int lessonCnt;
+    private LocalDate gymStartDt;
+    private LocalDate gymEndDt;
 
-    public static InvitationMappingResult create(Member member, String name, int lessonNum, int age, int height, int weight){
+    public static InvitationMappingResult create(Member member, String name, int lessonCnt, LocalDate gymStartDt, LocalDate gymEndDt){
         return InvitationMappingResult.builder()
                 .trainer(MemberDto.from(member))
                 .name(name)
-                .lessonNum(lessonNum)
-                .age(age)
-                .height(height)
-                .weight(weight)
+                .lessonCnt(lessonCnt)
+                .gymStartDt(gymStartDt)
+                .gymEndDt(gymEndDt)
                 .build();
     }
 }

--- a/src/main/java/com/tobe/healthy/member/domain/entity/Member.java
+++ b/src/main/java/com/tobe/healthy/member/domain/entity/Member.java
@@ -6,7 +6,9 @@ import com.tobe.healthy.gym.domain.entity.Gym;
 import com.tobe.healthy.member.domain.dto.in.MemberJoinCommand;
 import com.tobe.healthy.schedule.domain.entity.Schedule;
 import com.tobe.healthy.schedule.domain.entity.StandBySchedule;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.persistence.*;
+import jakarta.validation.constraints.Positive;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -44,6 +46,15 @@ public class Member extends BaseTimeEntity<Member, Long> {
 	private String password;
 
 	private String name;
+
+	@ColumnDefault("0")
+	private int age = 0;
+
+	@ColumnDefault("0")
+	private int height = 0;
+
+	@ColumnDefault("0")
+	private int weight = 0;
 
 	@OneToOne(fetch = LAZY, cascade = ALL)
 	@JoinColumn(name = "profile_id")
@@ -152,5 +163,17 @@ public class Member extends BaseTimeEntity<Member, Long> {
 
 	public void changeTrainerFeedback(AlarmStatus alarmStatus) {
 		this.feedbackAlarmStatus = alarmStatus;
+	}
+
+	public void changeAge(int age){
+		this.age = age;
+	}
+
+	public void changeHeight(int height){
+		this.height = height;
+	}
+
+	public void changeWeight(int weight){
+		this.weight = weight;
 	}
 }

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
@@ -210,6 +210,11 @@ public class MemberAuthController {
 			.build();
 	}
 
+	@Operation(summary = "구글 소셜 로그인", description = "인가코드로 구글에서 정보를 받아온 뒤에, 로그인 프로세스를 거친다. 비회원인 경우 회원가입 프로세스를 추가로 거친다.",
+			responses = {
+					@ApiResponse(responseCode = "500", description = "구글 소셜서버와 연동중 에러가 발생하였습니다."),
+					@ApiResponse(responseCode = "200", description = "요청 처리에 성공하였습니다.")
+			})
 	@PostMapping("/access-token/google")
 	public ResponseHandler<Tokens> getGoogleOAuth(@RequestBody SocialLoginCommand command) {
 		return ResponseHandler.<Tokens>builder()

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
@@ -168,7 +168,6 @@ public class MemberAuthController {
 	}
 
 	@Operation(summary = "초대링크 회원가입", responses = {
-		@ApiResponse(responseCode = "401", description = "이미 등록된 이메일입니다."),
 		@ApiResponse(responseCode = "405", description = "이미 등록된 닉네임입니다."),
 		@ApiResponse(responseCode = "200", description = "회원가입에 성공하였습니다.")
 	})

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberAuthController.java
@@ -156,7 +156,7 @@ public class MemberAuthController {
 	}
 
 	@Operation(summary = "초대링크 uuid 데이터 조회", responses = {
-		@ApiResponse(responseCode = "400", description = "잘못된 요청"),
+		@ApiResponse(responseCode = "404", description = "초대링크를 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "200", description = "성공")
 	})
 	@GetMapping("/invitation/uuid")
@@ -168,8 +168,15 @@ public class MemberAuthController {
 	}
 
 	@Operation(summary = "초대링크 회원가입", responses = {
-		@ApiResponse(responseCode = "405", description = "이미 등록된 닉네임입니다."),
-		@ApiResponse(responseCode = "200", description = "회원가입에 성공하였습니다.")
+			@ApiResponse(responseCode = "400", description = "이름의 길이는 2자 이상이여야 합니다."),
+			@ApiResponse(responseCode = "400", description = "이름은 한글 또는 영어만 입력할 수 있습니다."),
+			@ApiResponse(responseCode = "400", description = "확인 비밀번호가 일치하지 않습니다."),
+			@ApiResponse(responseCode = "400", description = "비밀번호는 영어 대/소문자와 숫자로 구성된 8자리 이상 문자여야 합니다."),
+			@ApiResponse(responseCode = "400", description = "아이디에 한글을 포함할 수 없습니다."),
+			@ApiResponse(responseCode = "400", description = "이미 등록된 아이디입니다."),
+			@ApiResponse(responseCode = "400", description = "이미 등록된 이메일입니다."),
+			@ApiResponse(responseCode = "400", description = "초대가입 회원 이름이 일치하지 않습니다."),
+			@ApiResponse(responseCode = "200", description = "회원가입에 성공하였습니다.")
 	})
 	@PostMapping("/invitation/join")
 	public ResponseHandler<MemberJoinCommandResult> joinWithInvitation(@RequestBody MemberJoinCommand request) {

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
@@ -16,6 +16,7 @@ import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 import org.springframework.web.multipart.MultipartFile;
@@ -128,12 +129,12 @@ public class MemberController {
 				.build();
 	}
 
-	@Operation(summary = "회원 운동기록 목록 조회", responses = {
+	@Operation(summary = "학생의 운동기록 목록 조회", responses = {
 			@ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
 			@ApiResponse(responseCode = "200", description = "운동기록, 페이징을 반환한다.")
 	})
 	@GetMapping("/{memberId}/workout-histories")
-	public ResponseHandler<List<WorkoutHistoryDto>> getWorkoutHistory(@PathVariable("memberId") Long memberId,
+	public ResponseHandler<List<WorkoutHistoryDto>> getWorkoutHistory(@Parameter(description = "학생 아이디", example = "to-be-healthy") @PathVariable("memberId") Long memberId,
 																	  Pageable pageable) {
 		return ResponseHandler.<List<WorkoutHistoryDto>>builder()
 				.data(workoutService.getWorkoutHistory(memberId, pageable))

--- a/src/main/java/com/tobe/healthy/member/repository/MemberRepository.java
+++ b/src/main/java/com/tobe/healthy/member/repository/MemberRepository.java
@@ -40,9 +40,9 @@ public interface MemberRepository extends JpaRepository<Member, Long>, MemberRep
 	@Query("select m from Member m where m.gym.id = :gymId and m.memberType = 'TRAINER' and m.delYn = false order by m.id desc")
 	List<Member> findAllTrainerByGym(@Param("gymId") Long gymId);
 
-	@Query("select m from Member m where m.id in(:members) and m.memberType = 'MEMBER' and m.delYn = false")
+	@Query("select m from Member m where m.id in(:members) and m.memberType = 'STUDENT' and m.delYn = false")
 	List<Member> findAll(Long[] members);
 
-	@Query("select m from Member m where m.id in(:members) and m.memberType = 'MEMBER' and m.delYn = false")
+	@Query("select m from Member m where m.id in(:members) and m.memberType = 'STUDENT' and m.delYn = false")
 	List<Member> findAll(List<Long> members);
 }

--- a/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
+++ b/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
@@ -10,6 +10,7 @@ import com.tobe.healthy.member.domain.entity.MemberType;
 import com.tobe.healthy.member.repository.MemberRepository;
 import com.tobe.healthy.trainer.domain.dto.TrainerMemberMappingDto;
 import com.tobe.healthy.trainer.domain.dto.in.MemberInviteCommand;
+import com.tobe.healthy.trainer.domain.dto.out.MemberInviteResultCommand;
 import com.tobe.healthy.trainer.domain.entity.TrainerMemberMapping;
 import com.tobe.healthy.trainer.respository.TrainerMemberMappingRepository;
 import jakarta.mail.internet.MimeMessage;
@@ -37,36 +38,44 @@ public class TrainerService {
     private final RedisService redisService;
     private final MemberRepository memberRepository;
     private final TrainerMemberMappingRepository mappingRepository;
-    private final MailService mailService;
 
     public TrainerMemberMappingDto addMemberOfTrainer(Long trainerId, Long memberId) {
-        memberRepository.findByIdAndMemberTypeAndDelYnFalse(trainerId, MemberType.TRAINER)
+        Member trainer = memberRepository.findByIdAndMemberTypeAndDelYnFalse(trainerId, MemberType.TRAINER)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        memberRepository.findById(memberId)
+        Member member = memberRepository.findById(memberId)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
         mappingRepository.findByTrainerIdAndMemberId(trainerId, memberId)
                 .ifPresent(i -> {throw new CustomException(ErrorCode.MEMBER_ALREADY_MAPPED);});
         TrainerMemberMapping mapping = TrainerMemberMapping.create(trainerId, memberId);
         mappingRepository.save(mapping);
+        member.registerGym(trainer.getGym());
         return TrainerMemberMappingDto.from(mapping);
     }
 
-    public void inviteMember(MemberInviteCommand command, Member trainer) {
+    public MemberInviteResultCommand inviteMember(MemberInviteCommand command, Member trainer) {
         memberRepository.findByIdAndMemberTypeAndDelYnFalse(trainer.getId(), MemberType.TRAINER)
                 .orElseThrow(() -> new CustomException(ErrorCode.MEMBER_NOT_FOUND));
-        List<String> emails = command.getEmails();
-        for(String email : emails){
-            memberRepository.findByEmail(email).ifPresent(i -> {throw new CustomException(ErrorCode.MEMBER_ALREADY_MAPPED);});
-            String uuid = System.currentTimeMillis() + "_" + UUID.randomUUID();
-            String invitationKey = RedisKeyPrefix.INVITATION.getDescription() + uuid;
-            String invitationLink = "https://www.to-be-healthy.site/invite?" + uuid;
-            mailService.sendInviteLink(email, trainer, invitationLink);
-            Map<String, String> invitedMapping = new HashMap<>() {{
-                put("trainerId", trainer.getId().toString());
-                put("email", email);
-            }};
-            redisService.setValuesWithTimeout(invitationKey, JSONObject.toJSONString(invitedMapping), 24 * 60 * 60 * 1000); // 1days
-        }
+
+        String name = command.getName();
+        int lessonNum = command.getLessonNum();
+        int age = command.getAge();
+        int height = command.getHeight();
+        int weight = command.getWeight();
+
+        String uuid = System.currentTimeMillis() + "_" + UUID.randomUUID();
+        String invitationKey = RedisKeyPrefix.INVITATION.getDescription() + uuid;
+        String invitationLink = "https://www.to-be-healthy.site/invite?uuid=" + uuid;
+
+        Map<String, String> invitedMapping = new HashMap<>() {{
+            put("trainerId", trainer.getId().toString());
+            put("name", name);
+            put("lessonNum", String.valueOf(lessonNum));
+            put("age", String.valueOf(age));
+            put("height", String.valueOf(height));
+            put("weight", String.valueOf(weight));
+        }};
+        redisService.setValuesWithTimeout(invitationKey, JSONObject.toJSONString(invitedMapping), 24 * 60 * 60 * 1000); // 1days
+        return new MemberInviteResultCommand(uuid, invitationLink);
     }
 
 }

--- a/src/main/java/com/tobe/healthy/trainer/domain/dto/in/MemberInviteCommand.java
+++ b/src/main/java/com/tobe/healthy/trainer/domain/dto/in/MemberInviteCommand.java
@@ -2,16 +2,28 @@ package com.tobe.healthy.trainer.domain.dto.in;
 
 import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.Positive;
 import lombok.Data;
-
-import java.util.ArrayList;
-import java.util.List;
 
 @Data
 public class MemberInviteCommand {
 
-    @Schema(description = "아이디" , example = "to-be-healthy")
-    @NotEmpty(message = "초대할 이메일을 추가해 주세요.")
-    private List<String> emails = new ArrayList<>();
+    @Schema(description = "이름" , example = "임채린")
+    @NotEmpty(message = "회원 이름을 추가해 주세요.")
+    private String name;
+
+    @Schema(description = "수업할 PT 횟수" , example = "10")
+    @Positive(message = "양수를 입력해주세요.")
+    private int lessonNum;
+
+    @Schema(description = "나이" , example = "20")
+    private int age = 0;
+
+    @Schema(description = "키" , example = "180")
+    private int height = 0;
+
+    @Schema(description = "몸무게" , example = "60")
+    private int weight = 0;
+
 
 }

--- a/src/main/java/com/tobe/healthy/trainer/domain/dto/in/MemberInviteCommand.java
+++ b/src/main/java/com/tobe/healthy/trainer/domain/dto/in/MemberInviteCommand.java
@@ -5,6 +5,8 @@ import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
 import lombok.Data;
 
+import java.time.LocalDate;
+
 @Data
 public class MemberInviteCommand {
 
@@ -14,16 +16,12 @@ public class MemberInviteCommand {
 
     @Schema(description = "수업할 PT 횟수" , example = "10")
     @Positive(message = "양수를 입력해주세요.")
-    private int lessonNum;
+    private int lessonCnt;
 
-    @Schema(description = "나이" , example = "20")
-    private int age = 0;
+    @Schema(description = "헬스장 이용권 시작날짜")
+    private LocalDate gymStartDt;
 
-    @Schema(description = "키" , example = "180")
-    private int height = 0;
-
-    @Schema(description = "몸무게" , example = "60")
-    private int weight = 0;
-
+    @Schema(description = "헬스장 이용권 종료날짜")
+    private LocalDate gymEndDt;
 
 }

--- a/src/main/java/com/tobe/healthy/trainer/domain/dto/out/MemberInviteResultCommand.java
+++ b/src/main/java/com/tobe/healthy/trainer/domain/dto/out/MemberInviteResultCommand.java
@@ -1,0 +1,21 @@
+package com.tobe.healthy.trainer.domain.dto.out;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import lombok.Data;
+
+@Data
+public class MemberInviteResultCommand {
+
+    @Schema(description = "트레이너/회원정보 매핑 uuid")
+    private String uuid;
+
+    @Schema(description = "초대링크")
+    private String invitationLink;
+
+    public MemberInviteResultCommand(String uuid, String invitationLink) {
+        this.uuid = uuid;
+        this.invitationLink = invitationLink;
+    }
+
+
+}

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -37,7 +37,7 @@ public class TrainerController {
     private final GymService gymService;
     private final MemberService memberService;
 
-    @Operation(summary = "트레이너가 학생 초대하기.", responses = {
+    @Operation(summary = "트레이너가 학생 초대하기", responses = {
 		@ApiResponse(responseCode = "400", description = "등록된 회원이 아닙니다."),
 		@ApiResponse(responseCode = "200", description = "회원초대가 완료 되었습니다.")
     })
@@ -57,8 +57,8 @@ public class TrainerController {
     })
     @PostMapping("/{trainerId}/members/{memberId}")
     @PreAuthorize("hasAuthority('ROLE_TRAINER')")
-    public ResponseHandler<TrainerMemberMappingDto> addMemberOfTrainer(@PathVariable("trainerId") Long trainerId,
-                                                                       @PathVariable("memberId") Long memberId) {
+    public ResponseHandler<TrainerMemberMappingDto> addMemberOfTrainer(@Parameter(description = "트레이너 ID") @PathVariable("trainerId") Long trainerId,
+                                                                       @Parameter(description = "학생 ID") @PathVariable("memberId") Long memberId) {
         return ResponseHandler.<TrainerMemberMappingDto>builder()
                 .data(trainerService.addMemberOfTrainer(trainerId, memberId))
                 .message("내 학생으로 등록되었습니다.")
@@ -66,12 +66,12 @@ public class TrainerController {
     }
 
 
-    @Operation(summary = "트레이너 학생들의 운동기록 목록 조회", responses = {
+    @Operation(summary = "트레이너가 관리하는 학생들의 운동기록 목록 조회하기", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
             @ApiResponse(responseCode = "200", description = "운동기록, 페이징을 반환한다.")
     })
     @GetMapping("/{trainerId}/workout-histories")
-    public ResponseHandler<List<WorkoutHistoryDto>> getWorkoutHistoryByTrainer(@PathVariable("trainerId") Long trainerId,
+    public ResponseHandler<List<WorkoutHistoryDto>> getWorkoutHistoryByTrainer(@Parameter(description = "트레이너 ID") @PathVariable("trainerId") Long trainerId,
                                                                                Pageable pageable) {
         return ResponseHandler.<List<WorkoutHistoryDto>>builder()
                 .data(workoutService.getWorkoutHistoryByTrainer(trainerId, pageable))

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -38,7 +38,8 @@ public class TrainerController {
     private final MemberService memberService;
 
     @Operation(summary = "트레이너가 학생 초대하기", responses = {
-		@ApiResponse(responseCode = "400", description = "등록된 회원이 아닙니다."),
+		@ApiResponse(responseCode = "400", description = "시작날짜와 종료날짜가 유효하지않습니다."),
+		@ApiResponse(responseCode = "400", description = "회원을 찾을 수 없습니다."),
 		@ApiResponse(responseCode = "200", description = "회원초대가 완료 되었습니다.")
     })
     @PostMapping("/invitation")

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -9,6 +9,7 @@ import com.tobe.healthy.member.domain.entity.AlarmStatus;
 import com.tobe.healthy.trainer.application.TrainerService;
 import com.tobe.healthy.trainer.domain.dto.TrainerMemberMappingDto;
 import com.tobe.healthy.trainer.domain.dto.in.MemberInviteCommand;
+import com.tobe.healthy.trainer.domain.dto.out.MemberInviteResultCommand;
 import com.tobe.healthy.workout.application.WorkoutHistoryService;
 import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
 import io.swagger.v3.oas.annotations.Operation;
@@ -41,10 +42,11 @@ public class TrainerController {
 		@ApiResponse(responseCode = "200", description = "회원초대가 완료 되었습니다.")
     })
     @PostMapping("/invitation")
-    public ResponseHandler<Void> inviteMember(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                              @Parameter(description = "이메일") @RequestBody MemberInviteCommand command) {
-        trainerService.inviteMember(command, customMemberDetails.getMember());
-        return ResponseHandler.<Void>builder()
+    @PreAuthorize("hasAuthority('ROLE_TRAINER')")
+    public ResponseHandler<MemberInviteResultCommand> inviteMember(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
+                                                                   @RequestBody MemberInviteCommand command) {
+        return ResponseHandler.<MemberInviteResultCommand>builder()
+                .data(trainerService.inviteMember(command, customMemberDetails.getMember()))
                 .message("회원초대가 완료 되었습니다.")
                 .build();
     }
@@ -54,6 +56,7 @@ public class TrainerController {
             @ApiResponse(responseCode = "200", description = "매핑ID, 트레이너ID, 회원ID를 반환한다.")
     })
     @PostMapping("/{trainerId}/members/{memberId}")
+    @PreAuthorize("hasAuthority('ROLE_TRAINER')")
     public ResponseHandler<TrainerMemberMappingDto> addMemberOfTrainer(@PathVariable("trainerId") Long trainerId,
                                                                        @PathVariable("memberId") Long memberId) {
         return ResponseHandler.<TrainerMemberMappingDto>builder()
@@ -94,7 +97,7 @@ public class TrainerController {
                     @ApiResponse(responseCode = "200", description = "수업 기록 여부가 변경되었습니다.")
             })
     @PatchMapping("/trainer-feedback")
-    @PreAuthorize("hasAuthority('TRAINER')")
+    @PreAuthorize("hasAuthority('ROLE_TRAINER')")
     public ResponseHandler<Boolean> changeTrainerFeedback(@Parameter(description = "변경할 수업 기록 상태", example = "ENABLED") @RequestParam AlarmStatus alarmStatus,
                                                           @AuthenticationPrincipal CustomMemberDetails member) {
         return ResponseHandler.<Boolean>builder()

--- a/src/main/java/com/tobe/healthy/workout/domain/dto/CompletedExerciseDto.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/dto/CompletedExerciseDto.java
@@ -2,6 +2,7 @@ package com.tobe.healthy.workout.domain.dto;
 
 import com.tobe.healthy.workout.domain.entity.CompletedExercise;
 import com.tobe.healthy.workout.domain.entity.WorkoutHistory;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.Positive;
 import lombok.AllArgsConstructor;
@@ -16,16 +17,21 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 public class CompletedExerciseDto {
 
+    @Schema(description = "운동 종류 ID", example = "1")
     private Long exerciseId;
 
+    @Schema(description = "운동 종류 이름", example = "90/90 Hamstring")
     private String name;
 
+    @Schema(description = "세트", example = "3")
     @Positive(message = "숫자를 입력해주세요.")
     private int setNum;
 
+    @Schema(description = "무게", example = "20")
     @Positive(message = "숫자를 입력해주세요.")
     private int weight;
 
+    @Schema(description = "반복횟수", example = "10")
     @Positive(message = "숫자를 입력해주세요.")
     private int numberOfCycles;
 

--- a/src/main/java/com/tobe/healthy/workout/domain/dto/in/HistoryAddCommand.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/dto/in/HistoryAddCommand.java
@@ -1,6 +1,7 @@
 package com.tobe.healthy.workout.domain.dto.in;
 
 import com.tobe.healthy.workout.domain.dto.CompletedExerciseDto;
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -16,9 +17,11 @@ import java.util.List;
 @NoArgsConstructor
 public class HistoryAddCommand {
 
+    @Schema(description = "게시글 내용" , example = "오운완~!!")
     @NotEmpty(message = "내용을 입력해 주세요.")
     private String content;
 
+    @Schema(description = "완료한 운동 목록")
     @NotNull(message = "운동을 추가해 주세요.")
     private List<CompletedExerciseDto> completedExercises = new ArrayList<>();
 

--- a/src/main/java/com/tobe/healthy/workout/domain/dto/in/HistoryCommentAddCommand.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/dto/in/HistoryCommentAddCommand.java
@@ -1,5 +1,6 @@
 package com.tobe.healthy.workout.domain.dto.in;
 
+import io.swagger.v3.oas.annotations.media.Schema;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import lombok.AllArgsConstructor;
@@ -15,8 +16,10 @@ import java.util.List;
 @NoArgsConstructor
 public class HistoryCommentAddCommand {
 
+    @Schema(description = "부모 댓글 아이디", example = "1")
     private Long parentCommentId;
 
+    @Schema(description = "댓글 내용", example = "댓글입니다.")
     @NotEmpty(message = "내용을 입력해 주세요.")
     private String content;
 

--- a/src/main/java/com/tobe/healthy/workout/presentation/CommentController.java
+++ b/src/main/java/com/tobe/healthy/workout/presentation/CommentController.java
@@ -7,6 +7,7 @@ import com.tobe.healthy.workout.application.CommentService;
 import com.tobe.healthy.workout.domain.dto.WorkoutHistoryCommentDto;
 import com.tobe.healthy.workout.domain.dto.in.HistoryCommentAddCommand;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -34,26 +35,26 @@ public class CommentController {
     private final CommonService commonService;
     private final CommentService commentService;
 
-    @Operation(summary = "운동기록 댓글 조회", responses = {
+    @Operation(summary = "운동기록의 댓글을 조회한다.", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
             @ApiResponse(responseCode = "200", description = "운동기록의 댓글, 페이징을 반환한다.")
     })
     @GetMapping("/{workoutHistoryId}/comments")
-    public ResponseHandler<List<WorkoutHistoryCommentDto>> getCommentsByHistoryId(@PathVariable("workoutHistoryId") Long workoutHistoryId,
-                                                                                 Pageable pageable) {
+    public ResponseHandler<List<WorkoutHistoryCommentDto>> getCommentsByHistoryId(@Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId,
+                                                                                  Pageable pageable) {
         return ResponseHandler.<List<WorkoutHistoryCommentDto>>builder()
                 .data(commentService.getCommentsByWorkoutHistoryId(workoutHistoryId, pageable))
                 .message("댓글이 조회되었습니다.")
                 .build();
     }
 
-    @Operation(summary = "운동기록 댓글(답글) 등록", responses = {
+    @Operation(summary = "운동기록에 댓글(답글)을 등록한다", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
             @ApiResponse(responseCode = "200", description = "운동기록 댓글을 반환한다.")
     })
     @PostMapping("/{workoutHistoryId}/comments")
     public ResponseHandler<WorkoutHistoryCommentDto> addComment(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                                @PathVariable("workoutHistoryId") Long workoutHistoryId,
+                                                                @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId,
                                                                 @Valid HistoryCommentAddCommand command) {
         return ResponseHandler.<WorkoutHistoryCommentDto>builder()
                 .data(commentService.addComment(workoutHistoryId, command, customMemberDetails.getMember()))
@@ -61,14 +62,14 @@ public class CommentController {
                 .build();
     }
 
-    @Operation(summary = "운동기록 댓글 수정", responses = {
+    @Operation(summary = "운동기록의 댓글을 수정한다.", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
             @ApiResponse(responseCode = "200", description = "운동기록 댓글을 반환한다.")
     })
     @PutMapping("/{workoutHistoryId}/comments/{commentId}")
     public ResponseHandler<WorkoutHistoryCommentDto> updateComment(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                                  @PathVariable("workoutHistoryId") Long workoutHistoryId,
-                                                                  @PathVariable("commentId") Long commentId,
+                                                                   @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId,
+                                                                   @Parameter(description = "운동기록의 댓글 ID") @PathVariable("commentId") Long commentId,
                                                                   @Valid HistoryCommentAddCommand command) {
         return ResponseHandler.<WorkoutHistoryCommentDto>builder()
                 .data(commentService.updateComment(customMemberDetails.getMember(), workoutHistoryId, commentId, command))
@@ -76,13 +77,13 @@ public class CommentController {
                 .build();
     }
 
-    @Operation(summary = "운동기록 댓글 삭제", responses = {
+    @Operation(summary = "운동기록의 댓글을 삭제한다.", responses = {
             @ApiResponse(responseCode = "200", description = "운동기록 댓글 삭제 완료.")
     })
     @PatchMapping("/{workoutHistoryId}/comments/{commentId}")
     public ResponseHandler<Void> deleteComment(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                           @PathVariable("workoutHistoryId") Long workoutHistoryId,
-                                           @PathVariable("commentId") Long commentId) {
+                                               @Parameter(description = "운동기록 ID")@PathVariable("workoutHistoryId") Long workoutHistoryId,
+                                               @Parameter(description = "운동기록의 댓글 ID")@PathVariable("commentId") Long commentId) {
         commentService.deleteComment(customMemberDetails.getMember(), workoutHistoryId, commentId);
         return ResponseHandler.<Void>builder()
                 .message("댓글이 삭제되었습니다.")

--- a/src/main/java/com/tobe/healthy/workout/presentation/ExerciseController.java
+++ b/src/main/java/com/tobe/healthy/workout/presentation/ExerciseController.java
@@ -7,6 +7,7 @@ import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
 import com.tobe.healthy.workout.domain.entity.ExerciseCategory;
 import com.tobe.healthy.workout.domain.entity.PrimaryMuscle;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
@@ -30,8 +31,8 @@ public class ExerciseController {
             @ApiResponse(responseCode = "200", description = "운동 종류를 반환한다.")
     })
     @GetMapping
-    public ResponseHandler<List<ExerciseDto>> getExercise(@RequestParam(required = false) ExerciseCategory category,
-                                                          @RequestParam(required = false) PrimaryMuscle primaryMuscle,
+    public ResponseHandler<List<ExerciseDto>> getExercise(@Parameter(description = "운동 카테고리") @RequestParam(required = false) ExerciseCategory category,
+                                                          @Parameter(description = "사용하는 근육") @RequestParam(required = false) PrimaryMuscle primaryMuscle,
                                                           Pageable pageable) {
         return ResponseHandler.<List<ExerciseDto>>builder()
                 .data(exerciseService.getExercise(category, primaryMuscle, pageable))

--- a/src/main/java/com/tobe/healthy/workout/presentation/WorkoutHistoryController.java
+++ b/src/main/java/com/tobe/healthy/workout/presentation/WorkoutHistoryController.java
@@ -7,6 +7,7 @@ import com.tobe.healthy.workout.application.WorkoutHistoryService;
 import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
 import com.tobe.healthy.workout.domain.dto.in.HistoryAddCommand;
 import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import jakarta.validation.Valid;
@@ -52,7 +53,7 @@ public class WorkoutHistoryController {
             @ApiResponse(responseCode = "200", description = "운동기록 상세정보를 반환한다.")
     })
     @GetMapping("/{workoutHistoryId}")
-    public ResponseHandler<WorkoutHistoryDto> getWorkoutHistoryDetail(@PathVariable("workoutHistoryId") Long workoutHistoryId) {
+    public ResponseHandler<WorkoutHistoryDto> getWorkoutHistoryDetail(@Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId) {
         return ResponseHandler.<WorkoutHistoryDto>builder()
                 .data(workoutService.getWorkoutHistoryDetail(workoutHistoryId))
                 .message("운동기록이 조회되었습니다.")
@@ -64,7 +65,7 @@ public class WorkoutHistoryController {
     })
     @PatchMapping("/{workoutHistoryId}")
     public ResponseHandler<Void> deleteWorkoutHistory(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                  @PathVariable("workoutHistoryId") Long workoutHistoryId) {
+                                                      @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId) {
         workoutService.deleteWorkoutHistory(customMemberDetails.getMember(), workoutHistoryId);
         return ResponseHandler.<Void>builder()
                 .message("운동기록이 삭제되었습니다.")
@@ -77,7 +78,7 @@ public class WorkoutHistoryController {
     })
     @PutMapping("/{workoutHistoryId}")
     public ResponseHandler<WorkoutHistoryDto> updateWorkoutHistory(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                                  @PathVariable("workoutHistoryId") Long workoutHistoryId,
+                                                                   @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId,
                                                                   @Valid HistoryAddCommand command) {
         return ResponseHandler.<WorkoutHistoryDto>builder()
                 .data(workoutService.updateWorkoutHistory(customMemberDetails.getMember(), workoutHistoryId, command))
@@ -91,7 +92,7 @@ public class WorkoutHistoryController {
     })
     @PostMapping("/{workoutHistoryId}/like")
     public ResponseHandler<Void> likeWorkoutHistory(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                 @PathVariable("workoutHistoryId") Long workoutHistoryId) {
+                                                    @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId) {
         workoutService.likeWorkoutHistory(customMemberDetails.getMember(), workoutHistoryId);
         return ResponseHandler.<Void>builder()
                 .message("운동기록 좋아요에 성공하였습니다.")
@@ -104,7 +105,7 @@ public class WorkoutHistoryController {
     })
     @DeleteMapping("/{workoutHistoryId}/like")
     public ResponseHandler<Void> deleteLikeWorkoutHistory(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                       @PathVariable("workoutHistoryId") Long workoutHistoryId) {
+                                                          @Parameter(description = "운동기록 ID") @PathVariable("workoutHistoryId") Long workoutHistoryId) {
         workoutService.deleteLikeWorkoutHistory(customMemberDetails.getMember(), workoutHistoryId);
         return ResponseHandler.<Void>builder()
                 .message("운동기록 좋아요가 취소되었습니다.")


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요
초대가입 수정
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용
- 초대가입시 Redis에 저장하는 정보 수정(trainerId, name, lessonCnt, gymStartDt, gymEndDt) 및 만료기간 1일로 수정
- 초대가입시 메일 전송이 아닌 링크를 복사할 수 있도록 수정
- 초대가입시 트레이너가 입력한 정보로 헬스장 이용권 추가
-  스웨거 설명 정리
<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제
학생이 수업 신청할 때 수업권 갯수를 참조한 후 신청 가능하도록 수정이 필요할 것 같습니다!
<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->