### PR TITLE
트레이너 학생 상세조회 추가, 매핑안된 학생목록 조회 추가

### DIFF
--- a/src/main/java/com/tobe/healthy/diet/domain/dto/DietDto.java
+++ b/src/main/java/com/tobe/healthy/diet/domain/dto/DietDto.java
@@ -1,0 +1,23 @@
+package com.tobe.healthy.diet.domain.dto;
+
+import com.tobe.healthy.file.domain.dto.DietFileDto;
+import lombok.Builder;
+import lombok.Data;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+@Builder
+public class DietDto {
+
+    private Long dietId;
+    private List<DietFileDto> dietFiles = new ArrayList<>();
+
+    public static DietDto create(Long dietId, List<DietFileDto> dietFiles) {
+        return DietDto.builder()
+                .dietId(dietId)
+                .dietFiles(dietFiles)
+                .build();
+    }
+}

--- a/src/main/java/com/tobe/healthy/diet/domain/entity/Diet.java
+++ b/src/main/java/com/tobe/healthy/diet/domain/entity/Diet.java
@@ -1,0 +1,52 @@
+package com.tobe.healthy.diet.domain.entity;
+
+import com.tobe.healthy.common.BaseTimeEntity;
+import com.tobe.healthy.file.domain.entity.DietFile;
+import com.tobe.healthy.file.domain.entity.WorkoutHistoryFile;
+import com.tobe.healthy.member.domain.entity.Member;
+import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
+import com.tobe.healthy.workout.domain.entity.CompletedExercise;
+import com.tobe.healthy.workout.domain.entity.WorkoutHistoryComment;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.ColumnDefault;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Table(name = "diet")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Getter
+public class Diet extends BaseTimeEntity<Diet, Long> {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "diet_id")
+    private Long dietId;
+
+    private String content;
+
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne
+    @JoinColumn(name = "trainer_id")
+    private Member trainer;
+
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean delYn = false;
+
+    @ColumnDefault("0")
+    @Builder.Default
+    private Long likeCnt = 0L;
+
+    @Builder.Default
+    @OneToMany(mappedBy = "diet", cascade = CascadeType.ALL)
+    private List<DietFile> dietFiles = new ArrayList<>();
+
+}

--- a/src/main/java/com/tobe/healthy/diet/repository/DietRepository.java
+++ b/src/main/java/com/tobe/healthy/diet/repository/DietRepository.java
@@ -1,0 +1,7 @@
+package com.tobe.healthy.diet.repository;
+
+import com.tobe.healthy.diet.domain.entity.Diet;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface DietRepository extends JpaRepository<Diet, Long>, DietRepositoryCustom {
+}

--- a/src/main/java/com/tobe/healthy/diet/repository/DietRepositoryCustom.java
+++ b/src/main/java/com/tobe/healthy/diet/repository/DietRepositoryCustom.java
@@ -1,0 +1,10 @@
+package com.tobe.healthy.diet.repository;
+
+import com.tobe.healthy.file.domain.entity.DietFile;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface DietRepositoryCustom {
+    List<DietFile> findAllCreateAtToday(Long memberId, LocalDateTime start, LocalDateTime end);
+}

--- a/src/main/java/com/tobe/healthy/diet/repository/DietRepositoryCustomImpl.java
+++ b/src/main/java/com/tobe/healthy/diet/repository/DietRepositoryCustomImpl.java
@@ -1,0 +1,54 @@
+package com.tobe.healthy.diet.repository;
+
+import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.jpa.JPAExpressions;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import com.tobe.healthy.file.domain.entity.DietFile;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.ObjectUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+import static com.tobe.healthy.diet.domain.entity.QDiet.diet;
+import static com.tobe.healthy.file.domain.entity.QDietFile.dietFile;
+
+
+@Repository
+@RequiredArgsConstructor
+public class DietRepositoryCustomImpl implements DietRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public List<DietFile> findAllCreateAtToday(Long memberId, LocalDateTime start, LocalDateTime end) {
+        return queryFactory.select(dietFile)
+                .from(dietFile)
+                .where(JPAExpressions.selectFrom(diet)
+                        .where(diet.dietId.eq(dietFile.diet.dietId)
+                        , createdAtBetween(start, end)
+                        , delYnEq(false)
+                        , memberIdEq(memberId))
+                        .orderBy(diet.createdAt.desc())
+                        .limit(1)
+                        .exists())
+                .fetch();
+    }
+
+    private BooleanExpression delYnEq(boolean bool) {
+        return diet.delYn.eq(bool);
+    }
+
+    private BooleanExpression createdAtBetween(LocalDateTime start, LocalDateTime end) {
+        if (!ObjectUtils.isEmpty(start) && !ObjectUtils.isEmpty(end)) {
+            return diet.createdAt.between(start, end);
+        }
+        return null;
+    }
+
+    private BooleanExpression memberIdEq(Long memberId) {
+        return diet.member.id.eq(memberId);
+    }
+
+}

--- a/src/main/java/com/tobe/healthy/file/domain/dto/DietFileDto.java
+++ b/src/main/java/com/tobe/healthy/file/domain/dto/DietFileDto.java
@@ -1,0 +1,31 @@
+package com.tobe.healthy.file.domain.dto;
+
+import com.tobe.healthy.file.domain.entity.DietFile;
+import com.tobe.healthy.file.domain.entity.DietType;
+import lombok.Builder;
+import lombok.Data;
+
+@Data
+@Builder
+public class DietFileDto {
+
+    private Long id;
+    private String fileName;
+    private String originalName;
+    private String extension;
+    private Long fileSize;
+    private String fileUrl;
+    private DietType type;
+
+    public static DietFileDto from(DietFile dietFile) {
+        return DietFileDto.builder()
+                .id(dietFile.getId())
+                .fileName(dietFile.getFileName())
+                .originalName(dietFile.getOriginalName())
+                .extension(dietFile.getExtension())
+                .fileSize(dietFile.getFileSize())
+                .fileUrl(dietFile.getFileUrl())
+                .type(dietFile.getType())
+                .build();
+    }
+}

--- a/src/main/java/com/tobe/healthy/file/domain/entity/DietFile.java
+++ b/src/main/java/com/tobe/healthy/file/domain/entity/DietFile.java
@@ -1,0 +1,48 @@
+package com.tobe.healthy.file.domain.entity;
+
+import com.tobe.healthy.common.BaseTimeEntity;
+import com.tobe.healthy.diet.domain.entity.Diet;
+import com.tobe.healthy.workout.domain.entity.WorkoutHistory;
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+
+import static jakarta.persistence.GenerationType.IDENTITY;
+import static lombok.AccessLevel.PROTECTED;
+
+@Entity
+@NoArgsConstructor(access = PROTECTED)
+@AllArgsConstructor
+@Table(name = "diet_file")
+@Builder
+@Getter
+public class DietFile extends BaseTimeEntity<DietFile, Long> {
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "file_id")
+    private Long id;
+
+    private String fileName;
+    private String originalName;
+
+    @Column(name = "file_ext")
+    private String extension;
+
+    private Long fileSize;
+    private String fileUrl;
+
+    @ColumnDefault("false")
+    @Builder.Default
+    private Boolean delYn = false;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "diet_id")
+    private Diet diet;
+
+    private DietType type;
+
+}

--- a/src/main/java/com/tobe/healthy/file/domain/entity/DietFile.java
+++ b/src/main/java/com/tobe/healthy/file/domain/entity/DietFile.java
@@ -10,6 +10,7 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 import org.hibernate.annotations.ColumnDefault;
 
+import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
 
@@ -43,6 +44,8 @@ public class DietFile extends BaseTimeEntity<DietFile, Long> {
     @JoinColumn(name = "diet_id")
     private Diet diet;
 
+    @Enumerated(STRING)
+    @ColumnDefault("'BREAKFAST'")
     private DietType type;
 
 }

--- a/src/main/java/com/tobe/healthy/file/domain/entity/DietType.java
+++ b/src/main/java/com/tobe/healthy/file/domain/entity/DietType.java
@@ -1,0 +1,21 @@
+package com.tobe.healthy.file.domain.entity;
+
+import com.tobe.healthy.common.EnumMapperType;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+@AllArgsConstructor
+@Getter
+public enum DietType implements EnumMapperType {
+
+    BREAKFAST("breakfast"),
+    LUNCH("lunch"),
+    DINNER("dinner");
+
+    private final String description;
+
+    @Override
+    public String getCode() {
+        return name();
+    }
+}

--- a/src/main/java/com/tobe/healthy/member/application/MemberService.java
+++ b/src/main/java/com/tobe/healthy/member/application/MemberService.java
@@ -19,6 +19,7 @@ import com.tobe.healthy.member.domain.dto.in.*;
 import com.tobe.healthy.member.domain.dto.in.MemberFindIdCommand.MemberFindIdCommandResult;
 import com.tobe.healthy.member.domain.dto.in.OAuthInfo.NaverUserInfo;
 import com.tobe.healthy.member.domain.dto.out.InvitationMappingResult;
+import com.tobe.healthy.member.domain.dto.out.MemberInfoResult;
 import com.tobe.healthy.member.domain.dto.out.MemberJoinCommandResult;
 import com.tobe.healthy.member.domain.entity.AlarmStatus;
 import com.tobe.healthy.member.domain.entity.Member;
@@ -595,20 +596,10 @@ public class MemberService {
 		return map;
 	}
 
-	public MemberDto getMemberInfo(Long memberId) {
+	public MemberInfoResult getMemberInfo(Long memberId) {
 		memberRepository.findById(memberId)
 				.orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-
-		Member member = memberRepository.findByMemberIdWithProfile(memberId);
-
-		Optional<TrainerMemberMapping> mapping = mappingRepository.findTop1ByMemberIdOrderByCreatedAtDesc(memberId);
-
-		if (mapping.isPresent()) {
-			Long trainerId = mapping.map(m -> m.getTrainer().getId()).orElse(null);
-			Member trainer = memberRepository.findByMemberIdWithGym(trainerId);
-			return MemberDto.create(member, member.getProfileId(), trainer.getGym());
-		} else {
-			return MemberDto.create(member, member.getProfileId());
-		}
+		Member member = memberRepository.findByMemberIdWithProfileAndGym(memberId);
+		return MemberInfoResult.create(member);
 	}
 }

--- a/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberDetailResult.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberDetailResult.java
@@ -1,0 +1,41 @@
+package com.tobe.healthy.member.domain.dto.out;
+
+import com.querydsl.core.annotations.QueryProjection;
+import com.tobe.healthy.diet.domain.dto.DietDto;
+import com.tobe.healthy.file.domain.dto.DietFileDto;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Data
+public class MemberDetailResult {
+	private Long memberId;
+	private String name;
+	private String nickName;
+	private String fileUrl;
+	private String memo;
+	private int ranking;
+	private int lessonCnt;
+	private int remainLessonCnt;
+	private LocalDate lessonDt;
+	private LocalTime lessonStartTime;
+	private DietDto diet;
+
+	@QueryProjection
+	public MemberDetailResult(Long memberId, String name, String nickName, String fileUrl, String memo, int ranking, int lessonCnt, int remainLessonCnt, LocalDate lessonDt, LocalTime lessonStartTime) {
+		this.memberId = memberId;
+		this.name = name;
+		this.nickName = nickName;
+		this.fileUrl = fileUrl;
+		this.memo = memo;
+		this.ranking = ranking;
+		this.lessonCnt = lessonCnt;
+		this.remainLessonCnt = remainLessonCnt;
+		this.lessonDt = lessonDt;
+		this.lessonStartTime = lessonStartTime;
+	}
+
+}

--- a/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberInTeamResult.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberInTeamResult.java
@@ -1,13 +1,11 @@
-package com.tobe.healthy.gym.domain.dto;
+package com.tobe.healthy.member.domain.dto.out;
 
 import com.querydsl.core.annotations.QueryProjection;
-import com.tobe.healthy.member.domain.entity.Member;
 import lombok.Data;
 
-import java.time.LocalDate;
 
 @Data
-public class MemberInTeamDto {
+public class MemberInTeamResult {
 	private Long memberId;
 	private String name;
 	private String userId;
@@ -19,7 +17,7 @@ public class MemberInTeamDto {
 	private String fileUrl;
 
 	@QueryProjection
-	public MemberInTeamDto(Long memberId, String name, String userId, String email, int ranking, int lessonCnt, int remainLessonCnt, String nickName, String fileUrl) {
+	public MemberInTeamResult(Long memberId, String name, String userId, String email, int ranking, int lessonCnt, int remainLessonCnt, String nickName, String fileUrl) {
 		this.memberId = memberId;
 		this.name = name;
 		this.userId = userId;

--- a/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberInfoResult.java
+++ b/src/main/java/com/tobe/healthy/member/domain/dto/out/MemberInfoResult.java
@@ -1,0 +1,58 @@
+package com.tobe.healthy.member.domain.dto.out;
+
+import com.tobe.healthy.file.domain.dto.ProfileDto;
+import com.tobe.healthy.file.domain.entity.Profile;
+import com.tobe.healthy.gym.domain.dto.GymDto;
+import com.tobe.healthy.gym.domain.entity.Gym;
+import com.tobe.healthy.member.domain.dto.MemberDto;
+import com.tobe.healthy.member.domain.entity.AlarmStatus;
+import com.tobe.healthy.member.domain.entity.Member;
+import com.tobe.healthy.member.domain.entity.MemberType;
+import com.tobe.healthy.member.domain.entity.SocialType;
+import lombok.Builder;
+import lombok.Data;
+
+
+@Data
+@Builder
+public class MemberInfoResult {
+
+	private Long id;
+	private String userId;
+	private String email;
+	private String name;
+	private int age;
+	private int height;
+	private int weight;
+
+	private ProfileDto profile;
+	private GymDto gym;
+	private MemberType memberType;
+	private AlarmStatus pushAlarmStatus;
+	private AlarmStatus feedbackAlarmStatus;
+	private SocialType socialType;
+
+
+	public static MemberInfoResult create(Member member) {
+		MemberInfoResultBuilder builder = MemberInfoResult.builder()
+				.id(member.getId())
+				.userId(member.getUserId())
+				.email(member.getEmail())
+				.name(member.getName())
+				.age(member.getAge())
+				.height(member.getHeight())
+				.weight(member.getWeight())
+				.memberType(member.getMemberType())
+				.pushAlarmStatus(member.getPushAlarmStatus())
+				.feedbackAlarmStatus(member.getFeedbackAlarmStatus())
+				.socialType(member.getSocialType());
+
+		if(member.getProfileId() != null){
+			builder.profile(ProfileDto.from(member.getProfileId()));
+		}
+		if(member.getGym() != null){
+			builder.gym(GymDto.from(member.getGym()));
+		}
+		return builder.build();
+	}
+}

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
@@ -5,6 +5,7 @@ import com.tobe.healthy.config.security.CustomMemberDetails;
 import com.tobe.healthy.member.application.MemberService;
 import com.tobe.healthy.member.domain.dto.MemberDto;
 import com.tobe.healthy.member.domain.dto.in.MemberPasswordChangeCommand;
+import com.tobe.healthy.member.domain.dto.out.MemberInfoResult;
 import com.tobe.healthy.member.domain.entity.AlarmStatus;
 import com.tobe.healthy.workout.application.WorkoutHistoryService;
 import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
@@ -39,8 +40,8 @@ public class MemberController {
 			@ApiResponse(responseCode = "200", description = "회원 정보가 조회되었습니다.")
 	})
 	@GetMapping("/me")
-	public ResponseHandler<MemberDto> getMemberInfo(@AuthenticationPrincipal CustomMemberDetails member) {
-		return ResponseHandler.<MemberDto>builder()
+	public ResponseHandler<MemberInfoResult> getMemberInfo(@AuthenticationPrincipal CustomMemberDetails member) {
+		return ResponseHandler.<MemberInfoResult>builder()
 				.data(memberService.getMemberInfo(member.getMemberId()))
 				.message("회원정보가 조회 되었습니다.")
 				.build();
@@ -51,9 +52,9 @@ public class MemberController {
 			@ApiResponse(responseCode = "200", description = "회원 정보가 조회되었습니다.")
 	})
 	@GetMapping("/{memberId}")
-	public ResponseHandler<MemberDto> getMemberInfo(@Parameter(description = "조회할 회원 아이디", example = "1")
+	public ResponseHandler<MemberInfoResult> getMemberInfo(@Parameter(description = "조회할 회원 아이디", example = "1")
 													@PathVariable("memberId") Long memberId) {
-		return ResponseHandler.<MemberDto>builder()
+		return ResponseHandler.<MemberInfoResult>builder()
 				.data(memberService.getMemberInfo(memberId))
 				.message("회원정보가 조회 되었습니다.")
 				.build();

--- a/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.tobe.healthy.member.repository;
 
-import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
+import com.tobe.healthy.member.domain.dto.out.MemberDetailResult;
+import com.tobe.healthy.member.domain.dto.out.MemberInTeamResult;
 import com.tobe.healthy.member.domain.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -12,7 +13,9 @@ public interface MemberRepositoryCustom {
 
     Member findByMemberIdWithGym(Long trainerId);
     Member findByMemberIdWithProfile(Long memberId);
-    List<MemberInTeamDto> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable);
-
+    Member findByMemberIdWithProfileAndGym(Long memberId);
+    List<MemberInTeamResult> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable);
     Page<Member> findAllUnattachedMembers(String searchValue, String sortValue, Pageable pageable);
+    MemberDetailResult getMemberOfTrainer(Long memberId);
+
 }

--- a/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryCustom.java
+++ b/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryCustom.java
@@ -2,6 +2,7 @@ package com.tobe.healthy.member.repository;
 
 import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
 import com.tobe.healthy.member.domain.entity.Member;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 
 import java.util.List;
@@ -13,4 +14,5 @@ public interface MemberRepositoryCustom {
     Member findByMemberIdWithProfile(Long memberId);
     List<MemberInTeamDto> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable);
 
+    Page<Member> findAllUnattachedMembers(String searchValue, String sortValue, Pageable pageable);
 }

--- a/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryImpl.java
+++ b/src/main/java/com/tobe/healthy/member/repository/MemberRepositoryImpl.java
@@ -2,11 +2,16 @@ package com.tobe.healthy.member.repository;
 
 import com.querydsl.core.Tuple;
 import com.querydsl.core.types.OrderSpecifier;
+import com.querydsl.core.types.Predicate;
 import com.querydsl.core.types.dsl.BooleanExpression;
+import com.querydsl.core.types.dsl.DateTimeTemplate;
+import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.jpa.JPAExpressions;
 import com.querydsl.jpa.impl.JPAQueryFactory;
-import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
-import com.tobe.healthy.gym.domain.dto.QMemberInTeamDto;
+import com.tobe.healthy.member.domain.dto.out.MemberDetailResult;
+import com.tobe.healthy.member.domain.dto.out.MemberInTeamResult;
+import com.tobe.healthy.member.domain.dto.out.QMemberDetailResult;
+import com.tobe.healthy.member.domain.dto.out.QMemberInTeamResult;
 import com.tobe.healthy.member.domain.entity.Member;
 import com.tobe.healthy.member.domain.entity.MemberType;
 import lombok.RequiredArgsConstructor;
@@ -14,14 +19,19 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.support.PageableExecutionUtils;
 import org.springframework.stereotype.Repository;
+import static com.tobe.healthy.schedule.domain.entity.QSchedule.schedule;
 import org.springframework.util.ObjectUtils;
 
 
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
 import java.util.List;
 
 import static com.tobe.healthy.file.domain.entity.QProfile.profile;
 import static com.tobe.healthy.gym.domain.entity.QGym.gym;
 import static com.tobe.healthy.member.domain.entity.QMember.member;
+import static com.tobe.healthy.schedule.domain.entity.ReservationStatus.COMPLETED;
 import static com.tobe.healthy.trainer.domain.entity.QTrainerMemberMapping.trainerMemberMapping;
 
 
@@ -57,9 +67,24 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return m;
     }
 
-    public List<MemberInTeamDto> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable) {
+    @Override
+    public Member findByMemberIdWithProfileAndGym(Long memberId) {
+        Tuple tuple = queryFactory
+                .select(member, profile, gym)
+                .from(member)
+                .leftJoin(member.profileId, profile).fetchJoin()
+                .leftJoin(member.gym, gym).fetchJoin()
+                .where(memberIdEq(memberId), member.delYn.eq(false))
+                .fetchOne();
+        Member m = tuple.get(member);
+        m.registerProfile(tuple.get(profile));
+        m.registerGym(tuple.get(gym));
+        return m;
+    }
+
+    public List<MemberInTeamResult> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable) {
         return queryFactory
-                .select(new QMemberInTeamDto(member.id, member.name, member.userId, member.email,
+                .select(new QMemberInTeamResult(member.id, member.name, member.userId, member.email,
                         trainerMemberMapping.ranking, trainerMemberMapping.lessonCnt, trainerMemberMapping.remainLessonCnt,
                         member.nickname, profile.fileUrl))
                 .from(trainerMemberMapping)
@@ -102,6 +127,33 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         return PageableExecutionUtils.getPage(members, pageable, ()-> totalCnt );
     }
 
+    @Override
+    public MemberDetailResult getMemberOfTrainer(Long memberId) {
+        return queryFactory
+                .select(new QMemberDetailResult(member.id, member.name, member.nickname, profile.fileUrl
+                        , trainerMemberMapping.memo, trainerMemberMapping.ranking, trainerMemberMapping.lessonCnt
+                        , trainerMemberMapping.remainLessonCnt, schedule.lessonDt, schedule.lessonStartTime))
+                .from(member)
+                .leftJoin(profile)
+                .on(member.profileId.id.eq(profile.id))
+                .leftJoin(trainerMemberMapping)
+                .on(member.id.eq(trainerMemberMapping.member.id))
+                .leftJoin(schedule)
+                .on(member.id.eq(schedule.applicant.id)
+                        , schedule.delYn.eq(false)
+                        , schedule.reservationStatus.eq(COMPLETED)
+                        , lessonDateTimeAfterToday())
+                .where(memberIdEq(memberId), member.delYn.eq(false))
+                .orderBy(schedule.lessonDt.asc(), schedule.lessonStartTime.asc())
+                .limit(1)
+                .fetchOne();
+    }
+
+    private Predicate lessonDateTimeAfterToday() {
+        return schedule.lessonDt.after(LocalDate.now())
+                .or(schedule.lessonDt.goe(LocalDate.now()).and(schedule.lessonStartTime.after(LocalTime.now())));
+    }
+
     private BooleanExpression memberIdEq(Long memberId) {
         if (!ObjectUtils.isEmpty(memberId)) {
             return member.id.eq(memberId);
@@ -122,4 +174,5 @@ public class MemberRepositoryImpl implements MemberRepositoryCustom {
         }
         return member.id.asc();
     }
+
 }

--- a/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
+++ b/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
@@ -85,4 +85,5 @@ public class TrainerService {
         List<MemberDto> memberDtos = members.stream().map(MemberDto::from).collect(Collectors.toList());
         return memberDtos.isEmpty() ? null : memberDtos;
     }
+
 }

--- a/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
+++ b/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
@@ -42,7 +42,7 @@ public class TrainerService {
     public TrainerMemberMappingDto addMemberOfTrainer(Long trainerId, Long memberId, MemberLessonCommand command) {
         Member trainer = memberRepository.findByIdAndMemberTypeAndDelYnFalse(trainerId, MemberType.TRAINER)
                 .orElseThrow(() -> new CustomException(TRAINER_NOT_FOUND));
-        Member member = memberRepository.findById(memberId)
+        Member member = memberRepository.findByIdAndMemberTypeAndDelYnFalse(memberId, MemberType.STUDENT)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
         mappingRepository.findByTrainerIdAndMemberId(trainerId, memberId)
                 .ifPresent(i -> {throw new CustomException(MEMBER_ALREADY_MAPPED);});

--- a/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
+++ b/src/main/java/com/tobe/healthy/trainer/application/TrainerService.java
@@ -5,6 +5,7 @@ import com.tobe.healthy.common.RedisService;
 import com.tobe.healthy.config.error.CustomException;
 import com.tobe.healthy.config.error.ErrorCode;
 import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
+import com.tobe.healthy.member.domain.dto.MemberDto;
 import com.tobe.healthy.member.domain.entity.Member;
 import com.tobe.healthy.member.domain.entity.MemberType;
 import com.tobe.healthy.member.repository.MemberRepository;
@@ -17,11 +18,13 @@ import com.tobe.healthy.trainer.respository.TrainerMemberMappingRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.json.simple.JSONObject;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.*;
+import java.util.stream.Collectors;
 
 import static com.tobe.healthy.config.error.ErrorCode.*;
 
@@ -75,5 +78,11 @@ public class TrainerService {
     public List<MemberInTeamDto> findAllMyMemberInTeam(Long trainerId, String searchValue, String sortValue, Pageable pageable) {
         List<MemberInTeamDto> members = memberRepository.findAllMyMemberInTeam(trainerId, searchValue, sortValue, pageable);
         return members.isEmpty() ? null : members;
+    }
+
+    public List<MemberDto> findAllUnattachedMembers(String searchValue, String sortValue, Pageable pageable) {
+        Page<Member> members = memberRepository.findAllUnattachedMembers(searchValue, sortValue, pageable);
+        List<MemberDto> memberDtos = members.stream().map(MemberDto::from).collect(Collectors.toList());
+        return memberDtos.isEmpty() ? null : memberDtos;
     }
 }

--- a/src/main/java/com/tobe/healthy/trainer/domain/entity/TrainerMemberMapping.java
+++ b/src/main/java/com/tobe/healthy/trainer/domain/entity/TrainerMemberMapping.java
@@ -37,6 +37,8 @@ public class TrainerMemberMapping extends BaseTimeEntity {
     @ColumnDefault("999")
     private int ranking = 999;
 
+    private String memo;
+
 
     public static TrainerMemberMapping create(Member trainer, Member member, int lessonCnt, int remainLessonCnt) {
         return TrainerMemberMapping.builder()
@@ -48,11 +50,12 @@ public class TrainerMemberMapping extends BaseTimeEntity {
     }
 
     @Builder
-    public TrainerMemberMapping(Member trainer, Member member, int lessonCnt, int remainLessonCnt) {
+    public TrainerMemberMapping(Member trainer, Member member, int lessonCnt, int remainLessonCnt, String memo) {
         this.trainer = trainer;
         this.member = member;
         this.lessonCnt = lessonCnt;
         this.remainLessonCnt = remainLessonCnt;
+        this.memo = memo;
     }
 
     public void changeRanking(int ranking){

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -57,7 +57,9 @@ public class TrainerController {
     }
 
     @Operation(summary = "트레이너가 내 학생으로 등록하기", responses = {
-            @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
+            @ApiResponse(responseCode = "400", description = "이미 등록된 회원입니다."),
+            @ApiResponse(responseCode = "404", description = "트레이너가 존재하지 않습니다."),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않습니다."),
             @ApiResponse(responseCode = "200", description = "매핑ID, 트레이너ID, 회원ID를 반환한다.")
     })
     @PostMapping("/{trainerId}/members/{memberId}")
@@ -70,7 +72,6 @@ public class TrainerController {
                 .message("내 학생으로 등록되었습니다.")
                 .build();
     }
-
 
     @Operation(summary = "트레이너가 관리하는 학생들의 운동기록 목록 조회하기", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -5,6 +5,7 @@ import com.tobe.healthy.config.security.CustomMemberDetails;
 import com.tobe.healthy.gym.application.GymService;
 import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
 import com.tobe.healthy.member.application.MemberService;
+import com.tobe.healthy.member.domain.dto.MemberDto;
 import com.tobe.healthy.member.domain.entity.AlarmStatus;
 import com.tobe.healthy.trainer.application.TrainerService;
 import com.tobe.healthy.trainer.domain.dto.TrainerMemberMappingDto;
@@ -19,6 +20,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -98,6 +100,23 @@ public class TrainerController {
         return ResponseHandler.<List<MemberInTeamDto>>builder()
                 .data(trainerService.findAllMyMemberInTeam(member.getMemberId(), searchValue, sortValue, pageable))
                 .message("트레이너가 관리하는 학생을 조회하였습니다.")
+                .build();
+    }
+
+    @Operation(summary = "트레이너가 가입된(매핑 안 된) 학생들을 조회한다.", description = "트레이너가 가입된(매핑 안 된) 학생들을 조회한다.",
+            responses = {
+                    @ApiResponse(responseCode = "200", description = "트레이너가 가입된 학생 조회 완료")
+            })
+    @GetMapping("unattached-members")
+    @PreAuthorize("hasAuthority('ROLE_TRAINER')")
+    public ResponseHandler<List<MemberDto>> findAllUnattachedMembers(@Parameter(description = "검색할 이름", example = "임채린")
+                                                                           @RequestParam(required = false) String searchValue,
+                                                                     @Parameter(description = "정렬 조건", example = "memberId")
+                                                                           @RequestParam(required = false, defaultValue = "memberId") String sortValue,
+                                                                     Pageable pageable) {
+        return ResponseHandler.<List<MemberDto>>builder()
+                .data(trainerService.findAllUnattachedMembers(searchValue, sortValue, pageable))
+                .message("트레이너가 가입된 학생을 조회하였습니다.")
                 .build();
     }
 

--- a/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
+++ b/src/main/java/com/tobe/healthy/trainer/presentation/TrainerController.java
@@ -3,9 +3,10 @@ package com.tobe.healthy.trainer.presentation;
 import com.tobe.healthy.common.ResponseHandler;
 import com.tobe.healthy.config.security.CustomMemberDetails;
 import com.tobe.healthy.gym.application.GymService;
-import com.tobe.healthy.gym.domain.dto.MemberInTeamDto;
+import com.tobe.healthy.member.domain.dto.out.MemberDetailResult;
 import com.tobe.healthy.member.application.MemberService;
 import com.tobe.healthy.member.domain.dto.MemberDto;
+import com.tobe.healthy.member.domain.dto.out.MemberInTeamResult;
 import com.tobe.healthy.member.domain.entity.AlarmStatus;
 import com.tobe.healthy.trainer.application.TrainerService;
 import com.tobe.healthy.trainer.domain.dto.TrainerMemberMappingDto;
@@ -20,7 +21,6 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.access.prepost.PreAuthorize;
@@ -73,6 +73,21 @@ public class TrainerController {
                 .build();
     }
 
+    @Operation(summary = "트레이너가 학생 상세 조회", responses = {
+            @ApiResponse(responseCode = "404", description = "트레이너가 존재하지 않습니다."),
+            @ApiResponse(responseCode = "404", description = "회원이 존재하지 않습니다."),
+            @ApiResponse(responseCode = "200", description = "학생 상세를 반환한다.")
+    })
+    @GetMapping("/{trainerId}/members/{memberId}")
+    @PreAuthorize("hasAuthority('ROLE_TRAINER')")
+    public ResponseHandler<MemberDetailResult> getMemberOfTrainer(@Parameter(description = "트레이너 ID") @PathVariable("trainerId") Long trainerId,
+                                                                       @Parameter(description = "학생 ID") @PathVariable("memberId") Long memberId) {
+        return ResponseHandler.<MemberDetailResult>builder()
+                .data(trainerService.getMemberOfTrainer(trainerId, memberId))
+                .message("학생 상세가 조회되었습니다.")
+                .build();
+    }
+
     @Operation(summary = "트레이너가 관리하는 학생들의 운동기록 목록 조회하기", responses = {
             @ApiResponse(responseCode = "400", description = "잘못된 요청 입력"),
             @ApiResponse(responseCode = "200", description = "운동기록, 페이징을 반환한다.")
@@ -92,13 +107,13 @@ public class TrainerController {
             })
     @GetMapping("/members")
     @PreAuthorize("hasAuthority('ROLE_TRAINER')")
-    public ResponseHandler<List<MemberInTeamDto>> findAllMyMemberInTrainer(@AuthenticationPrincipal CustomMemberDetails member,
+    public ResponseHandler<List<MemberInTeamResult>> findAllMyMemberInTrainer(@AuthenticationPrincipal CustomMemberDetails member,
                                                                            @Parameter(description = "검색할 이름", example = "임채린")
                                                                            @RequestParam(required = false) String searchValue,
                                                                            @Parameter(description = "정렬 조건", example = "ranking, memberId")
                                                                                @RequestParam(required = false, defaultValue = "memberId") String sortValue,
                                                                            @PageableDefault(size = 100) Pageable pageable) {
-        return ResponseHandler.<List<MemberInTeamDto>>builder()
+        return ResponseHandler.<List<MemberInTeamResult>>builder()
                 .data(trainerService.findAllMyMemberInTeam(member.getMemberId(), searchValue, sortValue, pageable))
                 .message("트레이너가 관리하는 학생을 조회하였습니다.")
                 .build();

--- a/src/main/java/com/tobe/healthy/workout/domain/dto/WorkoutHistoryDto.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/dto/WorkoutHistoryDto.java
@@ -3,6 +3,7 @@ package com.tobe.healthy.workout.domain.dto;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.tobe.healthy.file.domain.dto.WorkoutHistoryFileDto;
 import com.tobe.healthy.member.domain.dto.MemberDto;
+import com.tobe.healthy.member.domain.entity.Member;
 import com.tobe.healthy.workout.domain.dto.in.HistoryAddCommand;
 import com.tobe.healthy.workout.domain.entity.WorkoutHistory;
 import lombok.AllArgsConstructor;
@@ -22,7 +23,7 @@ public class WorkoutHistoryDto {
 
     private Long workoutHistoryId;
     private String content;
-    private Long trainerId;
+    private MemberDto trainer;
     private MemberDto member;
     private Long likeCnt;
 
@@ -37,13 +38,12 @@ public class WorkoutHistoryDto {
     private List<CompletedExerciseDto> completedExercises = new ArrayList<>();
 
 
-    public static WorkoutHistoryDto create(HistoryAddCommand command, MemberDto memberDto, Long trainerId) {
-        return WorkoutHistoryDto.builder()
+    public static WorkoutHistoryDto create(HistoryAddCommand command, MemberDto memberDto) {
+        WorkoutHistoryDtoBuilder builder = WorkoutHistoryDto.builder()
                 .content(command.getContent())
                 .member(memberDto)
-                .multipartFiles(command.getFiles())
-                .trainerId(trainerId)
-                .build();
+                .multipartFiles(command.getFiles());
+                return builder.build();
     }
 
     public static WorkoutHistoryDto from(WorkoutHistory history) {
@@ -51,7 +51,6 @@ public class WorkoutHistoryDto {
                 .workoutHistoryId(history.getWorkoutHistoryId())
                 .content(history.getContent())
                 .member(MemberDto.from(history.getMember()))
-                .trainerId(history.getTrainerId())
                 .likeCnt(history.getLikeCnt())
                 .build();
     }

--- a/src/main/java/com/tobe/healthy/workout/domain/entity/WorkoutHistory.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/entity/WorkoutHistory.java
@@ -34,7 +34,9 @@ public class WorkoutHistory extends BaseTimeEntity<WorkoutHistory, Long> {
     @JoinColumn(name = "member_id")
     private Member member;
 
-    private Long trainerId;
+    @ManyToOne
+    @JoinColumn(name = "trainer_id")
+    private Member trainer;
 
     @ColumnDefault("false")
     @Builder.Default
@@ -57,12 +59,12 @@ public class WorkoutHistory extends BaseTimeEntity<WorkoutHistory, Long> {
     private List<CompletedExercise> completedExercises = new ArrayList<>();
 
 
-    public static WorkoutHistory create(WorkoutHistoryDto historyDto, Member member) {
+    public static WorkoutHistory create(WorkoutHistoryDto historyDto, Member member, Member trainer) {
         return WorkoutHistory.builder()
                 .workoutHistoryId(historyDto.getWorkoutHistoryId())
                 .content(historyDto.getContent())
                 .member(member)
-                .trainerId(historyDto.getTrainerId())
+                .trainer(trainer)
                 .build();
     }
 

--- a/src/main/java/com/tobe/healthy/workout/repository/WorkoutHistoryRepositoryCustom.java
+++ b/src/main/java/com/tobe/healthy/workout/repository/WorkoutHistoryRepositoryCustom.java
@@ -1,6 +1,7 @@
 package com.tobe.healthy.workout.repository;
 
 import com.tobe.healthy.file.domain.entity.WorkoutHistoryFile;
+import com.tobe.healthy.member.domain.entity.Member;
 import com.tobe.healthy.workout.domain.entity.WorkoutHistory;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -11,6 +12,6 @@ import java.util.List;
 public interface WorkoutHistoryRepositoryCustom {
 
     Page<WorkoutHistory> getWorkoutHistory(@Param("memberId") Long memberId, Pageable pageable);
-    Page<WorkoutHistory> getWorkoutHistoryByTrainer(@Param("trainerId") Long trainerId, Pageable pageable);
+    Page<WorkoutHistory> getWorkoutHistoryByTrainer(Member trainer, Pageable pageable);
     List<WorkoutHistoryFile> getWorkoutHistoryFile(@Param("ids") List<Long> ids);
 }

--- a/src/main/java/com/tobe/healthy/workout/repository/WorkoutHistoryRepositoryCustomImpl.java
+++ b/src/main/java/com/tobe/healthy/workout/repository/WorkoutHistoryRepositoryCustomImpl.java
@@ -6,6 +6,7 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tobe.healthy.file.domain.dto.WorkoutHistoryFileDto;
 import com.tobe.healthy.file.domain.entity.QWorkoutHistoryFile;
 import com.tobe.healthy.file.domain.entity.WorkoutHistoryFile;
+import com.tobe.healthy.member.domain.entity.Member;
 import com.tobe.healthy.workout.domain.dto.WorkoutHistoryDto;
 import com.tobe.healthy.workout.domain.entity.QWorkoutHistory;
 import com.tobe.healthy.workout.domain.entity.WorkoutHistory;
@@ -46,16 +47,16 @@ public class WorkoutHistoryRepositoryCustomImpl implements WorkoutHistoryReposit
     }
 
     @Override
-    public Page<WorkoutHistory> getWorkoutHistoryByTrainer(Long trainerId, Pageable pageable) {
+    public Page<WorkoutHistory> getWorkoutHistoryByTrainer(Member trainer, Pageable pageable) {
         Long totalCnt = queryFactory
                 .select(workoutHistory.count())
                 .from(workoutHistory)
-                .where(workoutHistory.trainerId.eq(trainerId), historyDeYnEq(false))
+                .where(workoutHistory.trainer.id.eq(trainer.getId()), historyDeYnEq(false))
                 .fetchOne();
         List<WorkoutHistory> workoutHistories =  queryFactory
                 .select(workoutHistory)
                 .from(workoutHistory)
-                .where(workoutHistory.trainerId.eq(trainerId), historyDeYnEq(false))
+                .where(workoutHistory.trainer.id.eq(trainer.getId()), historyDeYnEq(false))
                 .orderBy(workoutHistory.createdAt.desc())
                 .offset(pageable.getOffset())
                 .limit(pageable.getPageSize())

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
     open-in-view: false
   data:
     redis:
-      host: localhost #local 실행시 localhost
+      host: redis-compose #local 실행시 localhost
       port: 6379
 
 jwt:

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -35,7 +35,7 @@ spring:
     open-in-view: false
   data:
     redis:
-      host: redis-compose #local 실행시 localhost
+      host: localhost #local 실행시 localhost
       port: 6379
 
 jwt:
@@ -84,7 +84,7 @@ aws:
   s3:
     access-key: ${AWS_S3_ACCESS_KEY}
     secret-key: ${AWS_S3_SECRET_KEY}
-    bucket-name: to-be-healthy-bucket
+    bucket-name: ${AWS_S3_BUCKET_NAME}
 
 # Spring openapi
 springdoc:


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요
트레이너가 회원 조회 기능들 추가
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [x] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용
- 트레이너 학생 상세 조회 기능 추가
- 매핑안 된 학생목록 조회 기능 추가
- 운동기록 trainer 연관관계 (Long 에서 Member로) 맺도록 수정
- 내정보 조회시 profile, gym 정보 함께 반환하도록 수정
<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->