### PR TITLE
학생 스케줄 API 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@ build/
 src/main/generated/
 src/test/generated_tests/
 src/main/resources/serviceAccountKey.json
+src/main/resources/firebase-adminsdk.json
 !gradle/wrapper/gradle-wrapper.jar
 !**/src/main/**/build/
 !**/src/test/**/build/

--- a/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
+++ b/src/main/java/com/tobe/healthy/config/error/ErrorCode.java
@@ -58,6 +58,8 @@ public enum ErrorCode {
 	SCHEDULE_LESS_THAN_30_DAYS(BAD_REQUEST, "C_033", "일정 등록은 30일을 넘을 수 없습니다."),
 	START_DATE_AFTER_END_DATE(BAD_REQUEST, "C_034", "수업 시작일은 종료일보다 빨라야 합니다."),
 	SCHEDULE_ALREADY_EXISTS(BAD_REQUEST, "C_035", "이미 등록된 일정이 존재합니다."),
+	RESERVATION_NOT_VALID(BAD_REQUEST, "C_035", "예약 가능한 시간이 아닙니다."),
+	RESERVATION_CANCEL_NOT_VALID(BAD_REQUEST, "C_035", "취소 가능한 시간이 아닙니다."),
 
 	SERVER_ERROR(INTERNAL_SERVER_ERROR, "S_001", "서버에서 오류가 발생하였습니다."),
 	FILE_UPLOAD_ERROR(INTERNAL_SERVER_ERROR, "S_002", "파일 업로드중 에러가 발생하였습니다."),

--- a/src/main/java/com/tobe/healthy/diet/domain/dto/DietCommentDto.java
+++ b/src/main/java/com/tobe/healthy/diet/domain/dto/DietCommentDto.java
@@ -26,8 +26,6 @@ public class DietCommentDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-    @JsonIgnore
     private Long parentId;
     private Long orderNum;
     private boolean delYn;

--- a/src/main/java/com/tobe/healthy/schedule/application/ScheduleService.java
+++ b/src/main/java/com/tobe/healthy/schedule/application/ScheduleService.java
@@ -11,6 +11,7 @@ import static com.tobe.healthy.config.error.ErrorCode.START_DATE_AFTER_END_DATE;
 import static com.tobe.healthy.config.error.ErrorCode.TRAINER_NOT_MAPPED;
 import static com.tobe.healthy.member.domain.entity.MemberType.STUDENT;
 import static com.tobe.healthy.schedule.domain.entity.ReservationStatus.AVAILABLE;
+import static com.tobe.healthy.schedule.domain.entity.ReservationStatus.SOLD_OUT;
 import static java.time.LocalTime.NOON;
 
 import com.tobe.healthy.config.error.CustomException;
@@ -26,6 +27,7 @@ import com.tobe.healthy.schedule.domain.dto.out.MyStandbyScheduleResponse;
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResponse;
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult;
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleIdInfo;
+import com.tobe.healthy.schedule.domain.entity.ReservationStatus;
 import com.tobe.healthy.schedule.domain.entity.Schedule;
 import com.tobe.healthy.schedule.domain.entity.StandBySchedule;
 import com.tobe.healthy.schedule.repository.ScheduleRepository;
@@ -128,9 +130,13 @@ public class ScheduleService {
 		List<ScheduleCommandResult> schedule = scheduleRepository.findAllSchedule(searchCond, trainerId);
 
 		List<ScheduleCommandResult> morning = schedule.stream()
-				.filter(s -> NOON.isAfter(s.getLessonStartTime())).collect(Collectors.toList());
+				.filter(s -> NOON.isAfter(s.getLessonStartTime()))
+				.peek(s -> { if(s.getStandByName()!=null) s.setReservationStatus(SOLD_OUT); })
+				.collect(Collectors.toList());
 		List<ScheduleCommandResult> afternoon = schedule.stream()
-				.filter(s -> NOON.isBefore(s.getLessonStartTime())).collect(Collectors.toList());
+				.filter(s -> NOON.isBefore(s.getLessonStartTime()))
+				.peek(s -> { if(s.getStandByName()!=null) s.setReservationStatus(SOLD_OUT); })
+				.collect(Collectors.toList());
 		return ScheduleCommandResponse.create(morning, afternoon);
 	}
 

--- a/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyReservation.java
+++ b/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyReservation.java
@@ -1,0 +1,29 @@
+package com.tobe.healthy.schedule.domain.dto.out;
+
+import com.tobe.healthy.schedule.domain.entity.Schedule;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Builder
+public class MyReservation {
+    private Long scheduleId;
+    private LocalDate lessonDt;
+    private LocalTime lessonStartTime;
+    private LocalTime lessonEndTime;
+    private String trainerName;
+    private String reservationStatus;
+
+    public static MyReservation from(Schedule schedule) {
+        return MyReservation.builder().scheduleId(schedule.getId())
+                .lessonDt(schedule.getLessonDt())
+                .lessonStartTime(schedule.getLessonStartTime())
+                .lessonEndTime(schedule.getLessonEndTime())
+                .trainerName(schedule.getTrainer().getName() + " 트레이너")
+                .reservationStatus(schedule.getReservationStatus().name())
+                .build();
+    }
+}

--- a/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyReservationResponse.java
+++ b/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyReservationResponse.java
@@ -1,29 +1,24 @@
 package com.tobe.healthy.schedule.domain.dto.out;
 
-import com.tobe.healthy.schedule.domain.entity.Schedule;
+import com.tobe.healthy.course.domain.dto.CourseDto;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.util.ObjectUtils;
 
-import java.time.LocalDate;
-import java.time.LocalTime;
+import java.util.List;
 
 @Data
 @Builder
 public class MyReservationResponse {
-    private Long scheduleId;
-    private LocalDate lessonDt;
-    private LocalTime lessonStartTime;
-    private LocalTime lessonEndTime;
-    private String trainerName;
-    private String reservationStatus;
 
-    public static MyReservationResponse from(Schedule schedule) {
-        return MyReservationResponse.builder().scheduleId(schedule.getId())
-                .lessonDt(schedule.getLessonDt())
-                .lessonStartTime(schedule.getLessonStartTime())
-                .lessonEndTime(schedule.getLessonEndTime())
-                .trainerName(schedule.getTrainer().getName() + " 트레이너")
-                .reservationStatus(schedule.getReservationStatus().name())
+    private final CourseDto course;
+    private final List<MyReservation> reservations;
+
+    public static MyReservationResponse create(CourseDto course, List<MyReservation> reservations) {
+        return MyReservationResponse.builder()
+                .course(course)
+                .reservations(ObjectUtils.isEmpty(reservations) ? null : reservations)
                 .build();
     }
+
 }

--- a/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyStandbySchedule.java
+++ b/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyStandbySchedule.java
@@ -1,0 +1,29 @@
+package com.tobe.healthy.schedule.domain.dto.out;
+
+import com.tobe.healthy.schedule.domain.entity.StandBySchedule;
+import lombok.Builder;
+import lombok.Data;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+@Data
+@Builder
+public class MyStandbySchedule {
+    private Long scheduleId;
+    private String trainerName;
+    private LocalDate lessonDt;
+    private LocalTime lessonStartTime;
+    private LocalTime lessonEndTime;
+    private String reservationStatus;
+
+    public static MyStandbySchedule from(StandBySchedule standBySchedule) {
+        return MyStandbySchedule.builder()
+                .scheduleId(standBySchedule.getSchedule().getId())
+                .trainerName(standBySchedule.getSchedule().getTrainer().getName() + " 트레이너")
+                .lessonDt(standBySchedule.getSchedule().getLessonDt())
+                .lessonStartTime(standBySchedule.getSchedule().getLessonStartTime())
+                .lessonEndTime(standBySchedule.getSchedule().getLessonEndTime())
+                .build();
+    }
+}

--- a/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyStandbyScheduleResponse.java
+++ b/src/main/java/com/tobe/healthy/schedule/domain/dto/out/MyStandbyScheduleResponse.java
@@ -1,29 +1,26 @@
 package com.tobe.healthy.schedule.domain.dto.out;
 
+import com.tobe.healthy.course.domain.dto.CourseDto;
 import com.tobe.healthy.schedule.domain.entity.StandBySchedule;
 import lombok.Builder;
 import lombok.Data;
+import org.springframework.util.ObjectUtils;
 
 import java.time.LocalDate;
 import java.time.LocalTime;
+import java.util.List;
 
 @Data
 @Builder
 public class MyStandbyScheduleResponse {
-    private Long scheduleId;
-    private String trainerName;
-    private LocalDate lessonDt;
-    private LocalTime lessonStartTime;
-    private LocalTime lessonEndTime;
-    private String reservationStatus;
 
-    public static MyStandbyScheduleResponse from(StandBySchedule standBySchedule) {
+    private CourseDto course;
+    private List<MyStandbySchedule> myStandbySchedules;
+
+    public static MyStandbyScheduleResponse create(CourseDto course, List<MyStandbySchedule> myStandbySchedules) {
         return MyStandbyScheduleResponse.builder()
-                .scheduleId(standBySchedule.getSchedule().getId())
-                .trainerName(standBySchedule.getSchedule().getTrainer().getName() + " 트레이너")
-                .lessonDt(standBySchedule.getSchedule().getLessonDt())
-                .lessonStartTime(standBySchedule.getSchedule().getLessonStartTime())
-                .lessonEndTime(standBySchedule.getSchedule().getLessonEndTime())
+                .course(course)
+                .myStandbySchedules(ObjectUtils.isEmpty(myStandbySchedules) ? null : myStandbySchedules)
                 .build();
     }
 }

--- a/src/main/java/com/tobe/healthy/schedule/domain/entity/ReservationStatus.java
+++ b/src/main/java/com/tobe/healthy/schedule/domain/entity/ReservationStatus.java
@@ -9,7 +9,8 @@ import lombok.Getter;
 public enum ReservationStatus implements EnumMapperType {
 	COMPLETED("예약완료"),
 	AVAILABLE("예약가능"),
-	NO_SHOW("노쇼");
+	NO_SHOW("노쇼"),
+	SOLD_OUT("대기마감");
 
 	private final String description;
 

--- a/src/main/java/com/tobe/healthy/schedule/presentation/ScheduleController.java
+++ b/src/main/java/com/tobe/healthy/schedule/presentation/ScheduleController.java
@@ -6,10 +6,7 @@ import com.tobe.healthy.schedule.application.ScheduleService;
 import com.tobe.healthy.schedule.domain.dto.in.AutoCreateScheduleCommand;
 import com.tobe.healthy.schedule.domain.dto.in.RegisterScheduleCommand;
 import com.tobe.healthy.schedule.domain.dto.in.ScheduleSearchCond;
-import com.tobe.healthy.schedule.domain.dto.out.MyReservationResponse;
-import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResponse;
-import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult;
-import com.tobe.healthy.schedule.domain.dto.out.ScheduleIdInfo;
+import com.tobe.healthy.schedule.domain.dto.out.*;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
 import io.swagger.v3.oas.annotations.responses.ApiResponse;
@@ -141,9 +138,9 @@ public class ScheduleController {
 			})
 	@GetMapping("/my-reservation")
 	@PreAuthorize("hasAuthority('ROLE_STUDENT')")
-	public ResponseHandler<List<MyReservationResponse>> findAllMyReservation(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-																			 @ParameterObject ScheduleSearchCond searchCond) {
-		return ResponseHandler.<List<MyReservationResponse>>builder()
+	public ResponseHandler<MyReservationResponse> findAllMyReservation(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
+																	   @ParameterObject ScheduleSearchCond searchCond) {
+		return ResponseHandler.<MyReservationResponse>builder()
 				.data(scheduleService.findAllMyReservation(customMemberDetails.getMemberId(), searchCond))
 				.message("학생이 내 예약을 조회하였습니다.")
 				.build();

--- a/src/main/java/com/tobe/healthy/schedule/presentation/ScheduleWaitingController.java
+++ b/src/main/java/com/tobe/healthy/schedule/presentation/ScheduleWaitingController.java
@@ -4,6 +4,7 @@ import com.tobe.healthy.common.ResponseHandler;
 import com.tobe.healthy.config.security.CustomMemberDetails;
 import com.tobe.healthy.schedule.application.ScheduleService;
 import com.tobe.healthy.schedule.application.ScheduleWaitingService;
+import com.tobe.healthy.schedule.domain.dto.out.MyStandbySchedule;
 import com.tobe.healthy.schedule.domain.dto.out.MyStandbyScheduleResponse;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -63,8 +64,8 @@ public class ScheduleWaitingController {
 			})
 	@GetMapping("/my-standby")
 	@PreAuthorize("hasAuthority('ROLE_STUDENT')")
-	public ResponseHandler<List<MyStandbyScheduleResponse>> findAllMyStandbySchedule(@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
-		return ResponseHandler.<List<MyStandbyScheduleResponse>>builder()
+	public ResponseHandler<MyStandbyScheduleResponse> findAllMyStandbySchedule(@AuthenticationPrincipal CustomMemberDetails customMemberDetails) {
+		return ResponseHandler.<MyStandbyScheduleResponse>builder()
 				.data(scheduleService.findAllMyStandbySchedule(customMemberDetails.getMemberId()))
 				.message("학생이 대기중인 예약을 조회하였습니다.")
 				.build();

--- a/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepository.java
+++ b/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepository.java
@@ -15,6 +15,7 @@ public interface ScheduleRepository extends JpaRepository<Schedule, Long>, Sched
 	@Query("select s from Schedule s where s.trainer.id = :userId and s.id = :scheduleId and s.delYn = false")
 	Optional<Schedule> findScheduleByTrainerId(Long userId, Long scheduleId);
 
+	@EntityGraph(attributePaths = {"applicant"})
 	@Query("select s from Schedule s where s.applicant.id = :userId and s.id = :scheduleId and s.delYn = false")
 	Optional<Schedule> findScheduleByApplicantId(Long userId, Long scheduleId);
 

--- a/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepositoryCustom.java
+++ b/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepositoryCustom.java
@@ -2,8 +2,8 @@ package com.tobe.healthy.schedule.repository;
 
 import com.tobe.healthy.schedule.domain.dto.in.RegisterScheduleCommand;
 import com.tobe.healthy.schedule.domain.dto.in.ScheduleSearchCond;
-import com.tobe.healthy.schedule.domain.dto.out.MyReservationResponse;
-import com.tobe.healthy.schedule.domain.dto.out.MyStandbyScheduleResponse;
+import com.tobe.healthy.schedule.domain.dto.out.MyReservation;
+import com.tobe.healthy.schedule.domain.dto.out.MyStandbySchedule;
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult;
 import com.tobe.healthy.schedule.domain.entity.Schedule;
 
@@ -13,7 +13,7 @@ import java.util.Optional;
 public interface ScheduleRepositoryCustom {
 	List<ScheduleCommandResult> findAllSchedule(ScheduleSearchCond searchCond, Long trainerId);
 	List<ScheduleCommandResult> findAllByApplicantId(Long memberId);
-	List<MyReservationResponse> findAllMyReservation(Long memberId, ScheduleSearchCond searchCond);
-	List<MyStandbyScheduleResponse> findAllMyStandbySchedule(Long memberId);
+	List<MyReservation> findAllMyReservation(Long memberId, ScheduleSearchCond searchCond);
+	List<MyStandbySchedule> findAllMyStandbySchedule(Long memberId);
 	Optional<Schedule> findAvailableRegisterSchedule(RegisterScheduleCommand request, Long trainerId);
 }

--- a/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepositoryImpl.java
+++ b/src/main/java/com/tobe/healthy/schedule/repository/ScheduleRepositoryImpl.java
@@ -11,8 +11,8 @@ import com.querydsl.jpa.impl.JPAQueryFactory;
 import com.tobe.healthy.member.domain.entity.QMember;
 import com.tobe.healthy.schedule.domain.dto.in.RegisterScheduleCommand;
 import com.tobe.healthy.schedule.domain.dto.in.ScheduleSearchCond;
-import com.tobe.healthy.schedule.domain.dto.out.MyReservationResponse;
-import com.tobe.healthy.schedule.domain.dto.out.MyStandbyScheduleResponse;
+import com.tobe.healthy.schedule.domain.dto.out.MyReservation;
+import com.tobe.healthy.schedule.domain.dto.out.MyStandbySchedule;
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult;
 import com.tobe.healthy.schedule.domain.entity.Schedule;
 import com.tobe.healthy.schedule.domain.entity.StandBySchedule;
@@ -73,7 +73,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
 	}
 
 	@Override
-	public List<MyReservationResponse> findAllMyReservation(Long memberId, ScheduleSearchCond searchCond) {
+	public List<MyReservation> findAllMyReservation(Long memberId, ScheduleSearchCond searchCond) {
 		List<Schedule> schedules = queryFactory.select(schedule)
 				.from(schedule)
 				.innerJoin(schedule.applicant, new QMember("applicant")).fetchJoin()
@@ -81,11 +81,11 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
 				.where(schedule.applicant.id.eq(memberId), schedule.lessonDt.goe(LocalDate.now()), lessonDtEq(searchCond))
 				.orderBy(schedule.lessonDt.asc(), schedule.lessonStartTime.asc())
 				.fetch();
-		return schedules.stream().map(MyReservationResponse::from).collect(toList());
+		return schedules.stream().map(MyReservation::from).collect(toList());
 	}
 
 	@Override
-	public List<MyStandbyScheduleResponse> findAllMyStandbySchedule(Long memberId) {
+	public List<MyStandbySchedule> findAllMyStandbySchedule(Long memberId) {
 		List<StandBySchedule> results = queryFactory.select(standBySchedule)
 				.from(standBySchedule)
 				.innerJoin(standBySchedule.schedule, schedule).fetchJoin()
@@ -95,7 +95,7 @@ public class ScheduleRepositoryImpl implements ScheduleRepositoryCustom {
 						standBySchedule.schedule.lessonDt.goe(LocalDate.now()))
 				.orderBy(standBySchedule.schedule.lessonDt.asc(), standBySchedule.schedule.lessonStartTime.asc())
 				.fetch();
-		return results.stream().map(MyStandbyScheduleResponse::from).collect(toList());
+		return results.stream().map(MyStandbySchedule::from).collect(toList());
 	}
 
 	@Override

--- a/src/main/java/com/tobe/healthy/workout/application/WorkoutHistoryService.java
+++ b/src/main/java/com/tobe/healthy/workout/application/WorkoutHistoryService.java
@@ -17,12 +17,14 @@ import com.tobe.healthy.workout.repository.CompletedExerciseRepository;
 import com.tobe.healthy.workout.repository.ExerciseRepository;
 import com.tobe.healthy.workout.repository.WorkoutHistoryLikeRepository;
 import com.tobe.healthy.workout.repository.WorkoutHistoryRepository;
+import jakarta.mail.Multipart;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
 import java.util.List;
 import java.util.Optional;

--- a/src/main/java/com/tobe/healthy/workout/domain/dto/WorkoutHistoryCommentDto.java
+++ b/src/main/java/com/tobe/healthy/workout/domain/dto/WorkoutHistoryCommentDto.java
@@ -23,8 +23,6 @@ public class WorkoutHistoryCommentDto {
     private String content;
     private LocalDateTime createdAt;
     private LocalDateTime updatedAt;
-
-    @JsonIgnore
     private Long parentId;
     private Long orderNum;
     private boolean delYn;

--- a/src/main/java/com/tobe/healthy/workout/presentation/WorkoutHistoryController.java
+++ b/src/main/java/com/tobe/healthy/workout/presentation/WorkoutHistoryController.java
@@ -14,6 +14,9 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 @RestController
@@ -31,9 +34,9 @@ public class WorkoutHistoryController {
     })
     @PostMapping
     public ResponseHandler<WorkoutHistoryDto> addWorkoutHistory(@AuthenticationPrincipal CustomMemberDetails customMemberDetails,
-                                                                @Valid HistoryAddCommand command) {
+                                                                @Valid HistoryAddCommand request) {
         return ResponseHandler.<WorkoutHistoryDto>builder()
-                .data(workoutService.addWorkoutHistory(customMemberDetails.getMember(), command))
+                .data(workoutService.addWorkoutHistory(customMemberDetails.getMember(), request))
                 .message("운동기록이 등록되었습니다.")
                 .build();
     }


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"




## 작업 개요
학생 스케줄 API 수정
<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용
- 학생이 트레이너 일정 조회시 예약/대기/마감 상태 구분 추가
- 학생이 수업 신청/취소 시 가능한 시간 유효성 체크 추가
- 학생의 예약/대기 내역 조회시 수강권도 함께 조회
<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->