### PR TITLE
FCM 푸시 전송 API 추가

### DIFF
--- a/src/main/java/com/tobe/healthy/member/application/MemberService.java
+++ b/src/main/java/com/tobe/healthy/member/application/MemberService.java
@@ -1,5 +1,31 @@
 package com.tobe.healthy.member.application;
 
+import static com.tobe.healthy.config.error.ErrorCode.CONFIRM_PASSWORD_NOT_MATCHED;
+import static com.tobe.healthy.config.error.ErrorCode.FILE_UPLOAD_ERROR;
+import static com.tobe.healthy.config.error.ErrorCode.INVITE_LINK_NOT_FOUND;
+import static com.tobe.healthy.config.error.ErrorCode.INVITE_NAME_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.JSON_PARSING_ERROR;
+import static com.tobe.healthy.config.error.ErrorCode.MAIL_AUTH_CODE_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_EMAIL_DUPLICATION;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_ID_DUPLICATION;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_ID_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_NAME_LENGTH_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_NAME_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_NOT_FOUND;
+import static com.tobe.healthy.config.error.ErrorCode.MEMBER_NOT_MAPPED;
+import static com.tobe.healthy.config.error.ErrorCode.NOT_MATCH_PASSWORD;
+import static com.tobe.healthy.config.error.ErrorCode.PASSWORD_POLICY_VIOLATION;
+import static com.tobe.healthy.config.error.ErrorCode.PROFILE_ACCESS_FAILED;
+import static com.tobe.healthy.config.error.ErrorCode.REFRESH_TOKEN_NOT_FOUND;
+import static com.tobe.healthy.config.error.ErrorCode.REFRESH_TOKEN_NOT_VALID;
+import static com.tobe.healthy.config.error.ErrorCode.USERID_POLICY_VIOLATION;
+import static com.tobe.healthy.member.domain.entity.SocialType.GOOGLE;
+import static com.tobe.healthy.member.domain.entity.SocialType.KAKAO;
+import static com.tobe.healthy.member.domain.entity.SocialType.NAVER;
+import static org.apache.commons.lang3.StringUtils.isEmpty;
+import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
+import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
+
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.fasterxml.jackson.core.JsonProcessingException;
@@ -15,9 +41,17 @@ import com.tobe.healthy.config.error.OAuthException;
 import com.tobe.healthy.config.security.JwtTokenGenerator;
 import com.tobe.healthy.course.application.CourseService;
 import com.tobe.healthy.course.domain.dto.in.CourseAddCommand;
-import com.tobe.healthy.member.domain.dto.in.*;
+import com.tobe.healthy.member.domain.dto.in.IdToken;
+import com.tobe.healthy.member.domain.dto.in.MemberFindIdCommand;
 import com.tobe.healthy.member.domain.dto.in.MemberFindIdCommand.MemberFindIdCommandResult;
+import com.tobe.healthy.member.domain.dto.in.MemberFindPWCommand;
+import com.tobe.healthy.member.domain.dto.in.MemberJoinCommand;
+import com.tobe.healthy.member.domain.dto.in.MemberLoginCommand;
+import com.tobe.healthy.member.domain.dto.in.MemberPasswordChangeCommand;
+import com.tobe.healthy.member.domain.dto.in.MemoCommand;
+import com.tobe.healthy.member.domain.dto.in.OAuthInfo;
 import com.tobe.healthy.member.domain.dto.in.OAuthInfo.NaverUserInfo;
+import com.tobe.healthy.member.domain.dto.in.SocialLoginCommand;
 import com.tobe.healthy.member.domain.dto.out.InvitationMappingResult;
 import com.tobe.healthy.member.domain.dto.out.MemberInfoResult;
 import com.tobe.healthy.member.domain.dto.out.MemberJoinCommandResult;
@@ -31,6 +65,18 @@ import com.tobe.healthy.trainer.application.TrainerService;
 import com.tobe.healthy.trainer.domain.entity.TrainerMemberMapping;
 import com.tobe.healthy.trainer.respository.TrainerMemberMappingRepository;
 import io.jsonwebtoken.impl.Base64UrlCodec;
+import java.io.ByteArrayInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
+import java.util.Base64;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.UUID;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -45,20 +91,6 @@ import org.springframework.util.MultiValueMap;
 import org.springframework.web.multipart.MultipartFile;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
-
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.net.URLDecoder;
-import java.nio.charset.StandardCharsets;
-import java.util.*;
-import java.util.regex.Pattern;
-
-import static com.tobe.healthy.config.error.ErrorCode.*;
-import static com.tobe.healthy.member.domain.entity.SocialType.*;
-import static org.apache.commons.lang3.StringUtils.isEmpty;
-import static org.springframework.http.MediaType.APPLICATION_FORM_URLENCODED;
-import static org.springframework.http.MediaType.IMAGE_PNG_VALUE;
 
 @Service
 @RequiredArgsConstructor
@@ -620,12 +652,5 @@ public class MemberService {
         TrainerMemberMapping mapping = mappingRepository.findByTrainerIdAndMemberId(trainerId, mmeberId)
                 .orElseThrow(() -> new CustomException(MEMBER_NOT_MAPPED));
         mapping.changeMemo(command.getMemo());
-    }
-
-    public String registerFcmToken(String fcmToken, Long memberId) {
-        Member findMember = memberRepository.findById(memberId)
-                .orElseThrow(() -> new CustomException(MEMBER_NOT_FOUND));
-        findMember.registerFcmToken(fcmToken);
-        return fcmToken;
     }
 }

--- a/src/main/java/com/tobe/healthy/member/domain/entity/Member.java
+++ b/src/main/java/com/tobe/healthy/member/domain/entity/Member.java
@@ -1,23 +1,5 @@
 package com.tobe.healthy.member.domain.entity;
 
-import com.tobe.healthy.common.BaseTimeEntity;
-import com.tobe.healthy.gym.domain.entity.Gym;
-import com.tobe.healthy.member.domain.dto.in.MemberJoinCommand;
-import com.tobe.healthy.schedule.domain.entity.Schedule;
-import com.tobe.healthy.schedule.domain.entity.ScheduleWaiting;
-import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import org.hibernate.annotations.ColumnDefault;
-import org.hibernate.annotations.DynamicUpdate;
-
-import javax.annotation.Nullable;
-import java.util.ArrayList;
-import java.util.List;
-import java.util.UUID;
-
 import static com.tobe.healthy.member.domain.entity.AlarmStatus.ENABLED;
 import static com.tobe.healthy.member.domain.entity.MemberType.STUDENT;
 import static com.tobe.healthy.member.domain.entity.SocialType.NONE;
@@ -27,6 +9,31 @@ import static jakarta.persistence.EnumType.STRING;
 import static jakarta.persistence.FetchType.LAZY;
 import static jakarta.persistence.GenerationType.IDENTITY;
 import static lombok.AccessLevel.PROTECTED;
+
+import com.tobe.healthy.common.BaseTimeEntity;
+import com.tobe.healthy.gym.domain.entity.Gym;
+import com.tobe.healthy.member.domain.dto.in.MemberJoinCommand;
+import com.tobe.healthy.schedule.domain.entity.Schedule;
+import com.tobe.healthy.schedule.domain.entity.ScheduleWaiting;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.UUID;
+import javax.annotation.Nullable;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.ColumnDefault;
+import org.hibernate.annotations.DynamicUpdate;
 
 @Entity
 @NoArgsConstructor(access = PROTECTED)
@@ -94,8 +101,6 @@ public class Member extends BaseTimeEntity<Member, Long> {
 	private SocialType socialType = NONE;
 
 	private String nickname;
-
-	private String fcmToken;
 
 	@ColumnDefault("false")
 	private boolean delYn = false;
@@ -169,10 +174,6 @@ public class Member extends BaseTimeEntity<Member, Long> {
 
 	public void assignNickname(String nickname) {
 		this.nickname = nickname;
-	}
-
-	public void registerFcmToken(String fcmToken) {
-		this.fcmToken = fcmToken;
 	}
 
 	public void setMemberProfile(MemberProfile profile) {

--- a/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
+++ b/src/main/java/com/tobe/healthy/member/presentation/MemberController.java
@@ -241,16 +241,4 @@ public class MemberController {
 				.message("닉네임을 지정하였습니다.")
 				.build();
 	}
-
-	@Operation(summary = "FCM 토큰을 등록한다.", responses = {
-			@ApiResponse(responseCode = "404", description = "등록된 회원이 아닙니다."),
-			@ApiResponse(responseCode = "200", description = "토큰이 등록되었습니다.")
-	})
-	@PostMapping("/fcm-token")
-	public ResponseHandler<String> registerFcmToken(@RequestParam String fcmToken, @AuthenticationPrincipal CustomMemberDetails member) {
-		return ResponseHandler.<String>builder()
-				.data(memberService.registerFcmToken(fcmToken, member.getMemberId()))
-				.message("토큰을 저장하였습니다.")
-				.build();
-	}
 }

--- a/src/main/kotlin/com/tobe/healthy/config/FirebaseConfig.kt
+++ b/src/main/kotlin/com/tobe/healthy/config/FirebaseConfig.kt
@@ -5,27 +5,24 @@ import com.google.firebase.FirebaseApp
 import com.google.firebase.FirebaseOptions
 import com.tobe.healthy.log
 import org.springframework.beans.factory.annotation.Value
-import org.springframework.stereotype.Service
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
 import java.io.FileInputStream
-import javax.annotation.PostConstruct
 
-@Service
+@Configuration
 class FirebaseConfig(
     @Value("\${firebase.admin-sdk.file}")
     private val firebaseAdminsdkFile: String
 ) {
 
-    @PostConstruct
-    fun initializeFCM() {
+    @Bean
+    fun initFirebase(): FirebaseApp {
         FileInputStream(firebaseAdminsdkFile).use {
             val options = FirebaseOptions.builder()
                 .setCredentials(GoogleCredentials.fromStream(it))
                 .build()
-            log.info { "options => ${options}" }
-            if (FirebaseApp.getApps().isEmpty()) {
-                FirebaseApp.initializeApp(options)
-                log.info { "Firebase application has been initialized"}
-            }
+            log.info { "Firebase application has been initialized"}
+            return FirebaseApp.initializeApp(options)
         }
     }
 }

--- a/src/main/kotlin/com/tobe/healthy/push/application/FirebaseCloudMessageService.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/application/FirebaseCloudMessageService.kt
@@ -1,0 +1,73 @@
+package com.tobe.healthy.push.application
+
+import com.google.firebase.messaging.FirebaseMessaging
+import com.google.firebase.messaging.Message
+import com.google.firebase.messaging.WebpushConfig
+import com.google.firebase.messaging.WebpushNotification
+import com.tobe.healthy.config.error.CustomException
+import com.tobe.healthy.config.error.ErrorCode.MEMBER_NOT_FOUND
+import com.tobe.healthy.log
+import com.tobe.healthy.member.repository.MemberRepository
+import com.tobe.healthy.push.domain.MemberToken
+import com.tobe.healthy.push.domain.NotificationRequest
+import com.tobe.healthy.push.domain.NotificationResponse
+import com.tobe.healthy.push.domain.RegisterTokenResponse
+import com.tobe.healthy.push.repository.MemberTokenRepository
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+
+@Service
+@Transactional
+class FirebaseCloudMessageService(
+    private val memberRepository: MemberRepository,
+    private val memberTokenRepository: MemberTokenRepository
+) {
+
+    fun registerFcmToken(token: String, memberId: Long): RegisterTokenResponse {
+        val findMember = memberRepository.findByIdOrNull(memberId)
+            ?: throw CustomException(MEMBER_NOT_FOUND)
+
+        memberTokenRepository.findByMemberId(findMember.id)?.let {
+            it.changeToken(token)
+        } ?: let {
+            val memberToken = MemberToken.register(findMember, token)
+            memberTokenRepository.save(memberToken)
+        }
+
+        return RegisterTokenResponse(
+            name = findMember.name,
+            token = token
+        )
+    }
+
+    fun sendPushAlarm(request: NotificationRequest): NotificationResponse {
+        val message = Message.builder()
+            .setToken(request.token)
+            .setWebpushConfig(
+                WebpushConfig.builder()
+                    .putHeader("ttl", "300")
+                    .setNotification(
+                        WebpushNotification(
+                            request.title,
+                            request.message
+                        )
+                    )
+                    .build()
+            )
+            .build()
+
+        val response = FirebaseMessaging
+            .getInstance()
+            .sendAsync(message)
+            .get()
+
+        log.info("Sent message: ${response}")
+
+        return NotificationResponse.from(
+            request.title,
+            request.message
+        )
+    }
+}

--- a/src/main/kotlin/com/tobe/healthy/push/domain/MemberToken.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/domain/MemberToken.kt
@@ -1,0 +1,36 @@
+package com.tobe.healthy.push.domain
+
+import com.tobe.healthy.common.BaseTimeEntity
+import com.tobe.healthy.member.domain.entity.Member
+import jakarta.persistence.*
+import jakarta.persistence.FetchType.LAZY
+import jakarta.persistence.GenerationType.IDENTITY
+
+@Entity
+class MemberToken(
+
+    var token: String,
+
+    @OneToOne(fetch = LAZY)
+    @JoinColumn(name = "member_id")
+    val member: Member,
+
+    @Id
+    @GeneratedValue(strategy = IDENTITY)
+    @Column(name = "member_token_id")
+    val id: Long = 0
+) : BaseTimeEntity<MemberToken, Long>() {
+
+    fun changeToken(token: String) {
+        this.token = token
+    }
+
+    companion object {
+        fun register(member: Member, token: String): MemberToken {
+            return MemberToken(
+                member = member,
+                token = token
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tobe/healthy/push/domain/NotificationRequest.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/domain/NotificationRequest.kt
@@ -1,0 +1,8 @@
+package com.tobe.healthy.push.domain
+
+data class NotificationRequest(
+    val title: String,
+    val message: String,
+    // todo: 2024-05-07 화요일 오후 14:31 다른 조건으로 사용자를 구분하는 기능이 필요(사용자 이름 또는 id등으로) - seonwoo_jung
+    val token: String
+)

--- a/src/main/kotlin/com/tobe/healthy/push/domain/NotificationResponse.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/domain/NotificationResponse.kt
@@ -1,0 +1,15 @@
+package com.tobe.healthy.push.domain
+
+data class NotificationResponse(
+    val title: String,
+    val message: String
+) {
+    companion object {
+        fun from(title: String, message: String): NotificationResponse {
+            return NotificationResponse(
+                title = title,
+                message = message
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/tobe/healthy/push/domain/RegisterTokenResponse.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/domain/RegisterTokenResponse.kt
@@ -1,0 +1,7 @@
+package com.tobe.healthy.push.domain
+
+data class RegisterTokenResponse(
+    val name: String,
+    val token: String
+) {
+}

--- a/src/main/kotlin/com/tobe/healthy/push/presentation/PushController.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/presentation/PushController.kt
@@ -1,17 +1,12 @@
-package com.tobe.healthy.controller
+package com.tobe.healthy.push.presentation
 
-import com.tobe.healthy.config.FirebaseConfig
 import org.springframework.stereotype.Controller
 import org.springframework.web.bind.annotation.GetMapping
 
 @Controller
-class FcmController(
-    private val fireBase: FirebaseConfig
-) {
-
+class PushController {
     @GetMapping("/fcm")
     fun index(): String {
-        fireBase.initializeFCM()
         return "index"
     }
 }

--- a/src/main/kotlin/com/tobe/healthy/push/presentation/PushRestController.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/presentation/PushRestController.kt
@@ -1,0 +1,33 @@
+package com.tobe.healthy.push.presentation
+
+import com.tobe.healthy.ApiResultResponse
+import com.tobe.healthy.config.security.CustomMemberDetails
+import com.tobe.healthy.push.application.FirebaseCloudMessageService
+import com.tobe.healthy.push.domain.NotificationRequest
+import com.tobe.healthy.push.domain.NotificationResponse
+import com.tobe.healthy.push.domain.RegisterTokenResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.*
+
+@RestController
+@RequestMapping("/push")
+class PushRestController(
+    private val firebaseCloudMessageService: FirebaseCloudMessageService
+) {
+    @PostMapping("/register")
+    fun registerFcmToken(@RequestParam token: String,
+                         @AuthenticationPrincipal member: CustomMemberDetails): ApiResultResponse<RegisterTokenResponse> {
+        return ApiResultResponse(
+            message = "토큰을 저장하였습니다.",
+            data = firebaseCloudMessageService.registerFcmToken(token, member.memberId)
+        )
+    }
+
+    @PostMapping
+    fun sendPushAlarm(@RequestBody request: NotificationRequest): ApiResultResponse<NotificationResponse> {
+        return ApiResultResponse(
+            message = "푸시 전송에 성공하였습니다.",
+            data = firebaseCloudMessageService.sendPushAlarm(request)
+        )
+    }
+}

--- a/src/main/kotlin/com/tobe/healthy/push/repository/MemberTokenRepository.kt
+++ b/src/main/kotlin/com/tobe/healthy/push/repository/MemberTokenRepository.kt
@@ -1,0 +1,8 @@
+package com.tobe.healthy.push.repository
+
+import com.tobe.healthy.push.domain.MemberToken
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberTokenRepository : JpaRepository<MemberToken, Long> {
+    fun findByMemberId(memberId: Long): MemberToken?
+}

--- a/src/main/kotlin/com/tobe/healthy/schedule/application/TrainerScheduleService.kt
+++ b/src/main/kotlin/com/tobe/healthy/schedule/application/TrainerScheduleService.kt
@@ -1,19 +1,11 @@
 package com.tobe.healthy.schedule.application
 
 import com.tobe.healthy.config.error.CustomException
-import com.tobe.healthy.config.error.ErrorCode.MEMBER_NOT_FOUND
-import com.tobe.healthy.config.error.ErrorCode.SCHEDULE_ALREADY_EXISTS
-import com.tobe.healthy.config.error.ErrorCode.SCHEDULE_LESS_THAN_30_DAYS
-import com.tobe.healthy.config.error.ErrorCode.SCHEDULE_NOT_FOUND
-import com.tobe.healthy.config.error.ErrorCode.START_DATE_AFTER_END_DATE
-import com.tobe.healthy.config.error.ErrorCode.TRAINER_SCHEDULE_NOT_FOUND
-import com.tobe.healthy.member.domain.entity.Member
+import com.tobe.healthy.config.error.ErrorCode.*
 import com.tobe.healthy.member.repository.MemberRepository
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleIdInfo
-import com.tobe.healthy.schedule.domain.entity.ReservationStatus.AVAILABLE
-import com.tobe.healthy.schedule.domain.entity.ReservationStatus.COMPLETED
-import com.tobe.healthy.schedule.domain.entity.ReservationStatus.NO_SHOW
+import com.tobe.healthy.schedule.domain.entity.ReservationStatus.*
 import com.tobe.healthy.schedule.domain.entity.Schedule
 import com.tobe.healthy.schedule.entity.TrainerScheduleClosedDaysInfo
 import com.tobe.healthy.schedule.entity.TrainerScheduleInfo
@@ -52,6 +44,7 @@ class TrainerScheduleService(
         var lessonDt = request.startDt
         var startTime = findTrainerSchedule.lessonStartTime
         val schedules = mutableListOf<Schedule>()
+//        val closedShedule = mutableListOf<Schedule>()
 
         while (!lessonDt.isAfter(request.endDt)) {
             val endTime = startTime.plusMinutes(findTrainerSchedule.lessonTime.description.toLong())
@@ -63,12 +56,14 @@ class TrainerScheduleService(
             }
 
             findTrainerSchedule.trainerScheduleClosedDays?.forEach {
+                // 휴무일일 경우
                 if (it.closedDays == lessonDt.dayOfWeek) {
                     lessonDt = lessonDt.plusDays(ONE_DAY)
                     return@forEach
                 }
             }
 
+            // 점심시간일 경우
             if (isStartTimeEqualsLunchStartTime(findTrainerSchedule.lunchStartTime, startTime)) {
                 val duration = between(findTrainerSchedule.lunchStartTime, findTrainerSchedule.lunchEndTime)
                 startTime = startTime.plusMinutes(duration.toMinutes())
@@ -104,8 +99,8 @@ class TrainerScheduleService(
         }
     }
 
-    fun findAllSchedule(searchCond: ScheduleSearchCond, trainer: Member): List<ScheduleCommandResult?> {
-        return trainerScheduleRepository.findAllSchedule(searchCond, trainer)
+    fun findAllSchedule(searchCond: ScheduleSearchCond, trainerId: Long): List<ScheduleCommandResult?> {
+        return trainerScheduleRepository.findAllSchedule(searchCond, trainerId)
     }
 
     fun updateReservationStatusToNoShow(scheduleId: Long, trainerId: Long): ScheduleIdInfo {

--- a/src/main/kotlin/com/tobe/healthy/schedule/presentation/TrainerScheduleController.kt
+++ b/src/main/kotlin/com/tobe/healthy/schedule/presentation/TrainerScheduleController.kt
@@ -17,14 +17,7 @@ import io.swagger.v3.oas.annotations.tags.Tag
 import org.springdoc.core.annotations.ParameterObject
 import org.springframework.security.access.prepost.PreAuthorize
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.DeleteMapping
-import org.springframework.web.bind.annotation.GetMapping
-import org.springframework.web.bind.annotation.PathVariable
-import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestMapping
-import org.springframework.web.bind.annotation.RequestParam
-import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.*
 import java.time.format.DateTimeFormatter
 
 @RestController
@@ -100,7 +93,7 @@ class TrainerScheduleController(
                         @AuthenticationPrincipal customMemberDetails: CustomMemberDetails): ApiResultResponse<List<ScheduleCommandResult?>> {
         return ApiResultResponse(
             message = "전체 일정을 조회했습니다.",
-            data = trainerScheduleService.findAllSchedule(searchCond, customMemberDetails.member)
+            data = trainerScheduleService.findAllSchedule(searchCond, customMemberDetails.memberId)
         )
     }
 

--- a/src/main/kotlin/com/tobe/healthy/schedule/repository/trainer/TrainerScheduleRepositoryCustom.kt
+++ b/src/main/kotlin/com/tobe/healthy/schedule/repository/trainer/TrainerScheduleRepositoryCustom.kt
@@ -1,6 +1,5 @@
 package com.tobe.healthy.schedule.repository.trainer
 
-import com.tobe.healthy.member.domain.entity.Member
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult
 import com.tobe.healthy.schedule.domain.entity.ReservationStatus
 import com.tobe.healthy.schedule.domain.entity.Schedule
@@ -8,10 +7,10 @@ import com.tobe.healthy.schedule.entity.`in`.RegisterScheduleCommand
 import com.tobe.healthy.schedule.entity.`in`.ScheduleSearchCond
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.Optional
+import java.util.*
 
 interface TrainerScheduleRepositoryCustom {
-    fun findAllSchedule(searchCond: ScheduleSearchCond, member: Member): List<ScheduleCommandResult?>
+    fun findAllSchedule(searchCond: ScheduleSearchCond, trainerId: Long): List<ScheduleCommandResult?>
     fun findAvailableRegisterSchedule(request: RegisterScheduleCommand, trainerId: Long): Schedule?
     fun validateRegisterSchedule(lessonDt: LocalDate, startTime: LocalTime, localTime: LocalTime, trainerId: Long): Long
     fun findAvailableWaitingId(scheduleId: Long): Optional<Schedule>

--- a/src/main/kotlin/com/tobe/healthy/schedule/repository/trainer/TrainerScheduleRepositoryImpl.kt
+++ b/src/main/kotlin/com/tobe/healthy/schedule/repository/trainer/TrainerScheduleRepositoryImpl.kt
@@ -17,7 +17,7 @@ import org.springframework.stereotype.Repository
 import org.springframework.util.ObjectUtils
 import java.time.LocalDate
 import java.time.LocalTime
-import java.util.Optional
+import java.util.*
 
 @Repository
 class TrainerScheduleRepositoryImpl(
@@ -26,7 +26,7 @@ class TrainerScheduleRepositoryImpl(
 
     override fun findAllSchedule(
         searchCond: ScheduleSearchCond,
-        trainer: Member
+        trainerId: Long
     ): List<ScheduleCommandResult> {
         val results = queryFactory
             .select(schedule)
@@ -38,7 +38,7 @@ class TrainerScheduleRepositoryImpl(
             .where(
                 lessonDtMonthEq(searchCond.lessonDt),
                 lessonDtBetween(searchCond),
-                trainerIdEq(trainer),
+                trainerIdEq(trainerId),
                 delYnEq(false)
             )
             .orderBy(schedule.lessonDt.asc(), schedule.lessonStartTime.asc())

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -55,6 +55,6 @@
     }
 </script>
 <body>
-<h1>hi! fcm</h1>
+    <h1>hi! fcm</h1>
 </body>
 </html>

--- a/src/test/kotlin/com/tobe/healthy/schedule/application/TrainerScheduleServiceTest.kt
+++ b/src/test/kotlin/com/tobe/healthy/schedule/application/TrainerScheduleServiceTest.kt
@@ -1,26 +1,19 @@
 package com.tobe.healthy.schedule.application
 
-import com.tobe.healthy.config.error.CustomException
-import com.tobe.healthy.config.error.ErrorCode.*
+import com.tobe.healthy.log
 import com.tobe.healthy.member.domain.entity.Member
 import com.tobe.healthy.member.repository.MemberRepository
 import com.tobe.healthy.schedule.domain.dto.out.ScheduleCommandResult
-import com.tobe.healthy.schedule.domain.entity.LessonTime.ONE_HOUR
-import com.tobe.healthy.schedule.domain.entity.ReservationStatus.AVAILABLE
 import com.tobe.healthy.schedule.domain.entity.Schedule
 import com.tobe.healthy.schedule.entity.`in`.RegisterScheduleRequest
 import com.tobe.healthy.schedule.entity.`in`.ScheduleSearchCond
 import com.tobe.healthy.schedule.repository.trainer.TrainerScheduleRepository
 import io.kotest.assertions.fail
-import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.core.spec.style.BehaviorSpec
-import io.kotest.matchers.collections.shouldContainOnly
-import io.kotest.matchers.shouldBe
 import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.data.repository.findByIdOrNull
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDate.of
-import java.time.LocalTime
 
 @SpringBootTest
 @Transactional
@@ -30,89 +23,27 @@ class TrainerScheduleServiceTest(
     private val memberRepository: MemberRepository
 ) : BehaviorSpec({
     val requestSchedule = RegisterScheduleRequest(
-        startDt = of(2024, 12, 1),
-        endDt = of(2024, 12, 1),
-        startTime = LocalTime.of(10, 0),
-        endTime = LocalTime.of(13, 0),
-        closedDt = mutableListOf(),
-        sessionTime = ONE_HOUR
+        startDt = of(2029, 12, 1),
+        endDt = of(2029, 12, 1)
     )
-
-    val searchCondSchedule = ScheduleSearchCond(
-        lessonStartDt = of(2024, 12, 1),
-        lessonEndDt = of(2024, 12, 1)
-    )
-
-    val trainerId = 542L
 
     // 특정 상황 설정
     Given("트레이너가 일정을 등록하고") {
         val trainerId = 542L
         trainerScheduleService.registerSchedule(requestSchedule, trainerId)
-
         // 특정 상황 실행
         When("등록한 일정을 조회를 했을 때") {
-            val trainer = findMember(memberRepository, trainerId)
-            val schedules = trainerScheduleService.findAllSchedule(searchCondSchedule, trainer)
-
             // 기대하는 결과 확인
-            Then("일정 등록이 잘 되었는지 검증한다") {
-                schedules.size shouldBe 3
-                schedules.map { it?.lessonDt } shouldContainOnly mutableListOf(of(2024, 12, 1))
-            }
+            val searchScheduleCond = ScheduleSearchCond(
+                lessonDt = "202912"
+            )
+            val findAllSchedule = trainerScheduleService.findAllSchedule(searchScheduleCond, trainerId)
 
             Then("트레이너가 일정을 삭제하고 검증한다") {
-                trainerScheduleService.cancelTrainerSchedule(schedules[0]!!.scheduleId!!, trainerId)
-                val findSchedule = findSchedule(trainerScheduleRepository, schedules)
-
-                findSchedule.reservationStatus shouldBe AVAILABLE
-                findSchedule.applicant shouldBe null
+                for (schedule in findAllSchedule) {
+                    log.info { "schedule=> ${schedule}" }
+                }
             }
-        }
-    }
-
-    Given("트레이너가 일정을 등록한 뒤에") {
-
-        Then("수업 시작일이 종료일보다 미래여서 예외를 발생시킨다") {
-            val copyRequest = requestSchedule.copy(
-                startDt = of(2024, 12, 2)
-            )
-            val exception = shouldThrow<CustomException> {
-                trainerScheduleService.registerSchedule(copyRequest, trainerId)
-            }
-            exception.message shouldBe START_DATE_AFTER_END_DATE.message
-        }
-
-        Then("수업 시작시간이 종료일보다 미래여서 예외를 발생시킨다") {
-            val copyRequest = requestSchedule.copy(
-                startTime = LocalTime.of(17, 0)
-            )
-            val exception = shouldThrow<CustomException> {
-                trainerScheduleService.registerSchedule(copyRequest, trainerId)
-            }
-            exception.message shouldBe DATETIME_NOT_VALID.message
-        }
-
-        Then("등록할 수업 시간이 30일을 초과해서 예외를 발생시킨다") {
-            val copyRequest = requestSchedule.copy(
-                startDt = of(2025, 1, 1),
-                endDt = of(2025, 2, 10)
-            )
-            val exception = shouldThrow<CustomException> {
-                trainerScheduleService.registerSchedule(copyRequest, trainerId)
-            }
-            exception.message shouldBe SCHEDULE_LESS_THAN_30_DAYS.message
-        }
-
-        Then("시작 점심시간이 종료 점심시간보다 미래여서 예외를 발생시킨다") {
-            val copyRequest = requestSchedule.copy(
-                lunchStartTime = LocalTime.of(13, 0),
-                lunchEndTime = LocalTime.of(11, 0)
-            )
-            val exception = shouldThrow<CustomException> {
-                trainerScheduleService.registerSchedule(copyRequest, trainerId)
-            }
-            exception.message shouldBe LUNCH_TIME_INVALID.message
         }
     }
 })


### PR DESCRIPTION
[comment]: <> "PR 제목은 다음과 같은 형태로 작성하고, 리뷰어에는 팀원 전체를 할당합니다."
[comment]: <> "{Jira-Issue-number} {한 줄 축약 내용 또는 티켓 제목 원형 그대로 이용}"

1. FCM 토큰 또는 memberId로 푸시 알림 전송 API 구현


## 작업 개요

<!--
  ex) 고양이가 야옹 소리를 내도록 수정
-->



## 작업 분류

- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경



## 작업 상세 내용

<!--
  ex) 네 발 짐승 클래스에 `크앙` 함수 추가
-->



## 생각해볼 문제

<!--
  ex) wav 파일을 매번 입력하기 귀찮겠다.
-->



## 완료한 테스트

<!--
  ex) 로그인 API가 정상적으로 동작하는지 확인
-->