### PR TITLE
docs: 웹사이트 URL을 geonganghaejim.site로 수정

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
     <p align="center">피트니스 센터, 트레이너와 회원을 위한 일정 관리 앱의 백엔드 API 서버</p>
     <br />
     <p align="center">
-      <a href="https://main.to-be-healthy.shop/">웹 사이트</a>
+      <a href="https://geonganghaejim.site/">웹 사이트</a>
       ·
       <a href="https://geonganghaejim.site/swagger-ui/index.html">API 문서</a>
 <!--       ·
@@ -43,11 +43,11 @@
 
 ### Production
 
-[운영 환경](https://main.to-be-healthy.shop/) · [API 서버](https://geonganghaejim.site/) · [API 문서](https://geonganghaejim.site/swagger-ui/index.html)
+[운영 환경](https://geonganghaejim.site/) · [API 문서](https://geonganghaejim.site/swagger-ui/index.html)
 
 ### Development
 
-[개발 환경 데모](https://www.dev.to-be-healthy.shop/)
+<!-- TODO: dev 운영 도메인 확정되면 채우기 -->
 
 ### 테스트계정
 


### PR DESCRIPTION
## Summary
- 기존 README의 `https://main.to-be-healthy.shop/` 도메인이 더 이상 응답하지 않음(ECONNREFUSED) 확인
- 실제 운영 웹사이트는 `https://geonganghaejim.site/` 로 확인되어 헤더와 Production 섹션의 웹사이트 링크를 교체
- Production 섹션의 중복 "API 서버" 링크를 정리(웹사이트와 동일 도메인이므로)

## 확인 필요
- Development 데모 도메인 `https://www.dev.to-be-healthy.shop/` 도 응답하지 않음 → 일단 `<!-- TODO -->`로 비워둠. 새 dev URL 알려주시면 후속 PR로 채우겠습니다.