### PR TITLE
docs: 내부 아키텍처 설명 추가 (패키지·요청 흐름·런타임·테스트)

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,17 +88,87 @@ docker compose up -d
 
 ### 인프라
 
-- **Container** — Docker, docker-compose
+- **Container** — Docker, docker-compose (멀티스테이지 빌드)
 - **CI/CD** — GitHub Actions (`.github/workflows`)
 - **Monitoring** — Prometheus exporter via Micrometer
 <!-- TODO: 운영 인프라(클라우드 제공자, 배포 토폴로지 등) 한두 줄 추가 -->
 
 ### 프로젝트 구조
 
-<!-- TODO: src/main/java 하위 폴더 구조 캡쳐 이미지 첨부 -->
+```
+src/main/
+├── java/com/tobe/healthy/        # 레거시 + 신규 Java 모듈
+│   ├── member/                   # 회원·트레이너 (인증/프로필/권한)
+│   ├── schedule/                 # PT 스케줄 예약·변경
+│   ├── lessonhistory/            # 수업 이력·피드백·메모
+│   ├── gym/                      # 헬스장(센터) 정보·소속
+│   ├── notification/             # FCM·메일 알림
+│   └── config/                   # 공통 설정 (Security / Redis / OpenAPI 등)
+└── kotlin/com/tobe/healthy/      # Kotlin으로 새로 작성된 모듈 (점진 이전)
+```
 
-도메인 단위로 패키지를 나누고, 각 도메인 안에서 `controller / service / domain / repository` 계층을 분리했습니다.
+**피처-퍼스트 → 5계층 패키징.** 각 feature 하위에 동일한 5개 계층을 일관되게 둡니다.
 
-Spring Security 필터 체인 + JWT 인증, OAuth2 소셜 로그인, FCM 푸시 알림 같은 횡단 관심사는 별도 모듈로 떼어내어 도메인 코드가 인증/메시징 구현 세부에 묶이지 않도록 했습니다.
+| 계층 | 역할 |
+|---|---|
+| `presentation` | `*Controller` — 요청 매핑, DTO 바인딩, 인증된 사용자 추출 |
+| `application` | `*Service` — 트랜잭션 경계, 도메인 오케스트레이션, 외부 시스템 호출 |
+| `domain` | 엔티티·값 객체·도메인 규칙 |
+| `repository` | Spring Data JPA + QueryDSL. 동적 쿼리는 `*RepositoryCustom` / `*RepositoryImpl`로 분리 |
+| `config` | 모듈 단위 Spring 설정 |
 
-QueryDSL은 복잡한 검색·집계 쿼리에서 타입 안전한 동적 쿼리를 위해 사용하고, 단순 CRUD는 Spring Data JPA의 메서드 네이밍을 그대로 활용합니다.
+> DTO 컨벤션: 쓰기 명령은 `Command*`, 조회 응답은 `Retrieve*` 접두사를 사용합니다.
+
+### 요청 처리 흐름
+
+```
+HTTP ─▶ Spring Security Filter Chain ─▶ JWT 인증 ─▶ Controller (presentation)
+                                                          │
+                                                          ▼
+                                                  Service (application)
+                                                          │
+                              ┌───────────────────────────┼───────────────────────────┐
+                              ▼                           ▼                           ▼
+                  Repository (JPA / QueryDSL)        외부 통합                    Domain 객체
+                              │                     - FCM (Firebase Admin)
+                              ▼                     - SMTP (Spring Mail)
+                          MySQL 8                   - WebClient (외부 API)
+                              │
+                              ▼  (캐시 · 일회성 토큰)
+                            Redis 7
+```
+
+도메인 코드는 인증/메시징 구현 세부에 묶이지 않도록 횡단 관심사를 별도 모듈로 분리합니다. QueryDSL은 동적 검색·집계 쿼리에서 타입 안전한 빌더로 활용하고, 단순 CRUD는 Spring Data JPA 메서드 네이밍을 그대로 사용합니다.
+
+### 횡단 관심사
+
+- **인증 / 인가** — Spring Security 필터 체인 + JWT(jjwt 0.12)로 stateless 인증. OAuth2 Client로 소셜 로그인 통합.
+- **알림** — Firebase Admin SDK로 FCM 푸시, Spring Mail로 이메일. `notification` 모듈에서 통합 관리.
+- **로깅 / 디버깅** — P6Spy가 SQL을 정제된 형태로 로깅하여 N+1·슬로우 쿼리 추적을 쉽게 합니다.
+- **API 문서** — SpringDoc OpenAPI가 런타임에 OpenAPI 스펙과 Swagger UI를 자동 생성합니다 (`/swagger-ui/index.html`).
+- **모니터링** — Spring Actuator + Micrometer Prometheus 레지스트리. 컨테이너에서 관리 포트(`7070`)를 별도 노출하여 외부 API 포트와 분리.
+
+### 런타임 구성
+
+| 컴포넌트 | 역할 | 기본 포트 |
+|---|---|---|
+| API 서버 | Spring Boot 애플리케이션 (`app.jar`) | 8080 |
+| Management | Actuator / Prometheus 메트릭 | 7070 |
+| MySQL 8 | 메인 데이터 저장 (DB: `healthy`) | 3306 |
+| Redis 7 | 캐시 · 일회성 토큰 · 분산 락 | 6379 |
+| 파일 저장 | 업로드 파일 (`FILE_UPLOAD_DIR`, 기본 `/data/files`) | — |
+
+컨테이너 이미지는 멀티스테이지 Dockerfile (`gradle:8.5-jdk17` → `eclipse-temurin:17-jre-jammy`)로 빌드하고, 보안을 위해 non-root `appuser`(uid 1001)로 실행합니다. 로그는 `/app/logs/{info,warn,error}`로 레벨별 분리됩니다.
+
+### 테스트
+
+- **JUnit 5 + Spring Boot Test** — 통합 / 컨트롤러 슬라이스 테스트
+- **Kotest · MockK** — Kotlin 모듈의 BDD 스타일 · 모킹
+- **Reactor Test** — WebClient / 리액티브 흐름 검증
+- **Rest Assured** — 엔드포인트 통합 테스트
+- **H2** — 런타임 테스트용 인메모리 DB
+
+```bash
+./gradlew test                                   # 전체 테스트
+./gradlew test --tests '*ScheduleRegisterTest'   # 단일 클래스
+```


### PR DESCRIPTION
## Summary
- 기존 짧은 "프로젝트 구조" 단락을 실 코드 구조를 반영한 섹션으로 확장
- 4개 섹션 추가: 요청 처리 흐름 / 횡단 관심사 / 런타임 구성 / 테스트

## 근거 자료
- `AGENTS.md` — feature-first × 5계층(`presentation`/`application`/`domain`/`repository`/`config`) 컨벤션, DTO `Command*` / `Retrieve*`, Java+Kotlin 혼재
- `src/main/java/com/tobe/healthy` 패키지 트리 (member · schedule · lessonhistory · gym · notification)
- `build.gradle` — Spring Boot 3.5, Java 17, JPA + QueryDSL 5.1, Spring Security/OAuth2, jjwt, Firebase Admin, SpringDoc, P6Spy, Actuator + Micrometer Prometheus
- `Dockerfile` — 멀티스테이지 빌드, non-root `appuser`(uid 1001), 노출 포트 8080/7070, 로그 디렉터리 레벨별 분리
- `docker-compose.yml` — MySQL 8 (`healthy` DB) + Redis 7

## 비고
- 운영 인프라(클라우드/배포 토폴로지)와 폴더 구조 캡쳐 이미지는 여전히 `<!-- TODO -->` 상태입니다.